### PR TITLE
feat(models): add cancel download and delete model actions

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -151,9 +151,9 @@ pub struct AppState {
     pub(crate) vad_model_path: PathBuf,
     /// Lazily-loaded Silero VAD template.
     pub(crate) vad: LazyModel<SileroVad>,
-    /// Model IDs currently being downloaded. Prevents concurrent
-    /// downloads of the same model from corrupting the `.part` file.
-    pub(crate) in_flight_downloads: Arc<Mutex<std::collections::HashSet<String>>>,
+    /// Model IDs currently being downloaded, mapped to a cancel flag.
+    /// Setting the flag to `true` signals the download loop to abort.
+    pub(crate) in_flight_downloads: Arc<Mutex<std::collections::HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>>>,
 }
 
 use echo_domain::StreamingSessionId;
@@ -248,7 +248,7 @@ impl AppState {
             llm: LazyModel::new(),
             vad_model_path,
             vad: LazyModel::new(),
-            in_flight_downloads: Arc::new(Mutex::new(std::collections::HashSet::new())),
+            in_flight_downloads: Arc::new(Mutex::new(std::collections::HashMap::new())),
         })
     }
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -178,6 +178,9 @@ pub enum DownloadEvent {
     /// Download failed.
     #[serde(rename = "failed")]
     Failed { error: String },
+    /// Download was cancelled by the user.
+    #[serde(rename = "cancelled")]
+    Cancelled,
 }
 
 /// Download a model by id, streaming progress events to the frontend.
@@ -193,24 +196,26 @@ pub async fn download_model(
     on_event: Channel<DownloadEvent>,
 ) -> Result<(), IpcError> {
     // ── Guard: reject concurrent downloads of the same model ─────
+    let cancel_flag = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     {
         let mut guard = state
             .in_flight_downloads
             .lock()
             .unwrap_or_else(|p| p.into_inner());
-        if !guard.insert(model_id.clone()) {
+        if guard.contains_key(&model_id) {
             return Err(IpcError::new(
                 ErrorCode::SessionConflict,
                 format!("model {model_id} is already being downloaded"),
             ));
         }
+        guard.insert(model_id.clone(), cancel_flag.clone());
     }
     let downloads_handle = state.in_flight_downloads.clone();
     let mid = model_id.clone();
     // Ensure the guard is removed on all exit paths.
     let _cleanup = scopeguard::guard((), move |()| {
-        if let Ok(mut set) = downloads_handle.lock() {
-            set.remove(&mid);
+        if let Ok(mut map) = downloads_handle.lock() {
+            map.remove(&mid);
         }
     });
 
@@ -259,6 +264,14 @@ pub async fn download_model(
         let mut hasher = Sha256::new();
         let mut last_report = std::time::Instant::now();
         while let Some(chunk) = stream.next().await {
+            // ── Check cancel flag ────────────────────────────────
+            if cancel_flag.load(std::sync::atomic::Ordering::Relaxed) {
+                drop(file);
+                let _ = tokio::fs::remove_file(&tmp).await;
+                let _ = on_event.send(DownloadEvent::Cancelled);
+                return Ok(());
+            }
+
             let chunk =
                 chunk.map_err(|e| IpcError::network(format!("download stream error: {e}")))?;
             file.write_all(&chunk)
@@ -324,4 +337,61 @@ pub async fn unload_model(state: State<'_, AppState>, kind: String) -> Result<bo
         "vad" => Ok(state.vad.unload().await),
         _ => Err(IpcError::not_found(format!("unknown model kind: {kind}"))),
     }
+}
+
+/// Cancel an in-flight model download.
+///
+/// Sets the cancel flag for the download loop, which will clean up the
+/// `.part` file and send a `Cancelled` event.
+#[tauri::command]
+#[specta::specta]
+pub async fn cancel_download(
+    state: State<'_, AppState>,
+    model_id: String,
+) -> Result<bool, IpcError> {
+    let guard = state
+        .in_flight_downloads
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    if let Some(flag) = guard.get(&model_id) {
+        flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Delete a downloaded model from disk.
+///
+/// If the model is currently loaded in memory, it is unloaded first.
+#[tauri::command]
+#[specta::specta]
+pub async fn delete_model(
+    state: State<'_, AppState>,
+    model_id: String,
+) -> Result<(), IpcError> {
+    let rel_path = model_dest_path(&model_id)
+        .ok_or_else(|| IpcError::not_found(format!("unknown model: {model_id}")))?;
+    let dest = workspace_root().join(rel_path);
+
+    if !dest.exists() {
+        return Err(IpcError::not_found(format!(
+            "model file not found: {model_id}"
+        )));
+    }
+
+    // Unload the model from memory if it's currently loaded.
+    let kind = model_id.split('-').next().unwrap_or("");
+    match kind {
+        "asr" => { state.transcriber.unload().await; }
+        "llm" => { state.llm.unload().await; }
+        "vad" => { state.vad.unload().await; }
+        _ => {}
+    }
+
+    tokio::fs::remove_file(&dest)
+        .await
+        .map_err(|e| IpcError::storage(format!("failed to delete model: {e}")))?;
+
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,8 @@ pub fn run() {
             commands::models::get_model_status,
             commands::models::download_model,
             commands::models::unload_model,
+            commands::models::cancel_download,
+            commands::models::delete_model,
         ]);
 
     // In dev builds, export TypeScript bindings so the frontend can

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -39,6 +39,9 @@
     "targets": "all",
     "createUpdaterArtifacts": true,
     "category": "Productivity",
+    "macOS": {
+      "minimumSystemVersion": "11.0"
+    },
     "shortDescription": "Private, local-first meeting transcription",
     "longDescription": "EchoNote is a privacy-first desktop app that transcribes meetings and generates AI summaries entirely on-device.",
     "copyright": "Copyright © 2026 Luis MC",

--- a/src/features/settings/ModelManager.tsx
+++ b/src/features/settings/ModelManager.tsx
@@ -60,6 +60,8 @@ export function ModelManager({
                 models={items}
                 downloading={downloading}
                 onDownload={state.download}
+                onCancel={state.cancelDl}
+                onDelete={state.remove}
               />
             ))}
           </div>
@@ -98,11 +100,15 @@ function ModelGroup({
   models,
   downloading,
   onDownload,
+  onCancel,
+  onDelete,
 }: Readonly<{
   kind: string;
   models: ModelInfo[];
   downloading: DownloadProgress | null;
   onDownload: (id: string) => void;
+  onCancel: (id: string) => void;
+  onDelete: (id: string) => void;
 }>) {
   const { t } = useTranslation();
   return (
@@ -116,6 +122,8 @@ function ModelGroup({
           model={m}
           downloading={downloading}
           onDownload={onDownload}
+          onCancel={onCancel}
+          onDelete={onDelete}
         />
       ))}
     </div>
@@ -126,10 +134,14 @@ function ModelRow({
   model,
   downloading,
   onDownload,
+  onCancel,
+  onDelete,
 }: Readonly<{
   model: ModelInfo;
   downloading: DownloadProgress | null;
   onDownload: (id: string) => void;
+  onCancel: (id: string) => void;
+  onDelete: (id: string) => void;
 }>) {
   const { t } = useTranslation();
   const isDownloading = downloading?.modelId === model.id;
@@ -165,18 +177,40 @@ function ModelRow({
         )}
       </div>
 
-      {model.present ? (
-        <span className="shrink-0 rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
-          {t("models.installed")}
-        </span>
-      ) : (
+      {isDownloading && (
+        <button
+          type="button"
+          onClick={() => onCancel(model.id)}
+          className="shrink-0 rounded-md border border-red-200 bg-red-50 px-2.5 py-1 text-xs font-medium text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-300 dark:hover:bg-red-900/60"
+        >
+          {t("models.cancel")}
+        </button>
+      )}
+      {!isDownloading && model.present && (
+        <div className="flex shrink-0 items-center gap-1.5">
+          <span className="rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+            {t("models.installed")}
+          </span>
+          <button
+            type="button"
+            onClick={() => onDelete(model.id)}
+            className="rounded-md p-1 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+            title={t("models.delete")}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+              <path fillRule="evenodd" d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.285a1.5 1.5 0 0 0 1.493-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25Zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5ZM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.075l-.275-5.5A.75.75 0 0 1 6.05 6Zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.075l.275-5.5A.75.75 0 0 1 9.95 6Z" clipRule="evenodd" />
+            </svg>
+          </button>
+        </div>
+      )}
+      {!isDownloading && !model.present && (
         <button
           type="button"
           disabled={anyDownloading}
           onClick={() => onDownload(model.id)}
           className="shrink-0 rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
         >
-          {isDownloading ? t("models.downloading") : t("models.download", { size: formatBytes(model.sizeBytes) })}
+          {t("models.download", { size: formatBytes(model.sizeBytes) })}
         </button>
       )}
     </div>

--- a/src/hooks/useModelManager.ts
+++ b/src/hooks/useModelManager.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { downloadModel, getModelStatus } from "../ipc/client";
+import { cancelDownload, deleteModel, downloadModel, getModelStatus } from "../ipc/client";
+import { isIpcError } from "../types/ipc-error";
 import type { DownloadEvent, ModelInfo } from "../types/models";
 
 export type DownloadProgress = {
@@ -15,6 +16,8 @@ export type UseModelManager = {
   error: string | null;
   refresh: () => void;
   download: (modelId: string) => void;
+  cancelDl: (modelId: string) => void;
+  remove: (modelId: string) => void;
 };
 
 export function useModelManager(): UseModelManager {
@@ -33,7 +36,11 @@ export function useModelManager(): UseModelManager {
       })
       .catch((err) => {
         if (mountedRef.current) {
-          setError(err instanceof Error ? err.message : String(err));
+          let msg: string;
+          if (isIpcError(err)) msg = err.message;
+          else if (err instanceof Error) msg = err.message;
+          else msg = String(err);
+          setError(msg);
         }
       })
       .finally(() => {
@@ -69,18 +76,52 @@ export function useModelManager(): UseModelManager {
             setDownloading(null);
             setError(event.error);
             break;
+          case "cancelled":
+            setDownloading(null);
+            break;
         }
       };
 
       downloadModel(modelId, onEvent).catch((err) => {
         if (mountedRef.current) {
           setDownloading(null);
-          setError(err instanceof Error ? err.message : String(err));
+          let msg: string;
+          if (isIpcError(err)) msg = err.message;
+          else if (err instanceof Error) msg = err.message;
+          else msg = String(err);
+          setError(msg);
         }
       });
     },
     [downloading, fetchStatus],
   );
 
-  return { models, loading, downloading, error, refresh: fetchStatus, download };
+  const cancelDl = useCallback(
+    (modelId: string) => {
+      cancelDownload(modelId).catch(() => {});
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    (modelId: string) => {
+      setError(null);
+      deleteModel(modelId)
+        .then(() => {
+          if (mountedRef.current) fetchStatus();
+        })
+        .catch((err) => {
+          if (mountedRef.current) {
+            let msg: string;
+            if (isIpcError(err)) msg = err.message;
+            else if (err instanceof Error) msg = err.message;
+            else msg = String(err);
+            setError(msg);
+          }
+        });
+    },
+    [fetchStatus],
+  );
+
+  return { models, loading, downloading, error, refresh: fetchStatus, download, cancelDl, remove };
 }

--- a/src/hooks/useRecordingSession.ts
+++ b/src/hooks/useRecordingSession.ts
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import { useToast } from "../components/Toaster";
 import { startStreaming, stopStreaming } from "../ipc/client";
+import { isIpcError } from "../types/ipc-error";
 import {
   canStart as selectCanStart,
   canStop as selectCanStop,
@@ -219,10 +220,11 @@ export function useRecordingSession({
           handleEvent,
         );
       } catch (err) {
-        dispatch({
-          type: "BACKEND_ERROR",
-          message: err instanceof Error ? err.message : String(err),
-        });
+        let msg: string;
+        if (isIpcError(err)) msg = err.message;
+        else if (err instanceof Error) msg = err.message;
+        else msg = String(err);
+        dispatch({ type: "BACKEND_ERROR", message: msg });
       }
     },
     [handleEvent],
@@ -235,10 +237,11 @@ export function useRecordingSession({
     try {
       await stopStreaming(id);
     } catch (err) {
-      dispatch({
-        type: "BACKEND_ERROR",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      let msg: string;
+      if (isIpcError(err)) msg = err.message;
+      else if (err instanceof Error) msg = err.message;
+      else msg = String(err);
+      dispatch({ type: "BACKEND_ERROR", message: msg });
     }
   }, [stream]);
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,7 +122,9 @@
     "connecting": "Connecting…",
     "installed": "Installed",
     "downloading": "Downloading…",
-    "download": "Download ({{size}})"
+    "download": "Download ({{size}})",
+    "cancel": "Cancel",
+    "delete": "Delete model"
   },
   "errors": {
     "renderCrash": "fatal — render error",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -122,7 +122,9 @@
     "connecting": "Conectando…",
     "installed": "Instalado",
     "downloading": "Descargando…",
-    "download": "Descargar ({{size}})"
+    "download": "Descargar ({{size}})",
+    "cancel": "Cancelar",
+    "delete": "Eliminar modelo"
   },
   "errors": {
     "renderCrash": "fatal — error de renderizado",

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -92,7 +92,7 @@ async renameSpeaker(meetingId: MeetingId, speakerId: SpeakerId, label: string | 
  * ordered by FTS5 BM25 rank (best match first). Empty / whitespace-
  * only queries return an empty vec — the frontend wires this to
  * `onChange` debounced, so the initial empty state never errors.
- * 
+ *
  * `limit` defaults to 20 (a comfortable sidebar page); `0` means no
  * cap. The query is sanitised inside the storage layer, so the
  * frontend can pass raw user input without worrying about FTS5
@@ -108,7 +108,7 @@ async searchMeetings(query: string, limit: number | null) : Promise<Result<Meeti
 },
 /**
  * Generate (or regenerate) the local-LLM summary for a meeting.
- * 
+ *
  * `template` selects the prompt template: `"general"` (default),
  * `"oneOnOne"`, `"sprintReview"`, `"interview"`, `"salesCall"`, or
  * `"lecture"`. Passing `null` or omitting the field defaults to
@@ -138,14 +138,14 @@ async getSummary(meetingId: MeetingId) : Promise<Result<Summary | null, IpcError
 },
 /**
  * Run one chat turn against a meeting's transcript.
- * 
+ *
  * Each invocation streams the assistant's reply token-by-token through
  * `on_event` and resolves the IPC promise once the stream terminates
  * (with [`AskAboutMeetingEvent::Finished`] on success or
  * [`AskAboutMeetingEvent::Failed`] on a mid-decode error).
- * 
+ *
  * ## Lifecycle
- * 
+ *
  * 1. Pre-stream errors (meeting not found, empty question, model
  * not loaded) come back as `Err(String)` so the UI can show a
  * toast without parsing event variants.
@@ -163,9 +163,9 @@ async getSummary(meetingId: MeetingId) : Promise<Result<Summary | null, IpcError
  * is needed — symmetric with `start_streaming` was deliberately
  * not chosen because chat is bounded (one Q&A turn ≤ ~10s on
  * Qwen 14B, vs streaming sessions that can run hours).
- * 
+ *
  * ## Why we don't spawn a background task
- * 
+ *
  * Unlike `start_streaming`, which returns a session id and runs
  * indefinitely until `stop_streaming`, a chat turn is a single
  * bounded interaction. Draining the stream inline keeps the IPC
@@ -183,11 +183,11 @@ async askAboutMeeting(meetingId: MeetingId, history: ChatMessage[] | null, quest
 },
 /**
  * Export a meeting (with optional summary) to a file at `dest_path`.
- * 
+ *
  * The frontend is responsible for showing the save-file dialog (via
  * `@tauri-apps/plugin-dialog`) and passing the chosen path here. This
  * command generates the formatted content and writes it atomically.
- * 
+ *
  * **Security:** `dest_path` is validated to be inside the user's home
  * directory and must not contain path-traversal components (`..`).
  */
@@ -207,7 +207,7 @@ async getModelStatus() : Promise<ModelInfo[]> {
 },
 /**
  * Download a model by id, streaming progress events to the frontend.
- * 
+ *
  * When the catalog entry includes a SHA-256 digest the downloaded file
  * is verified before being promoted from `*.part` to its final path.
  * Concurrent downloads of the same model are rejected.
@@ -247,22 +247,22 @@ async unloadModel(kind: string) : Promise<Result<boolean, IpcError>> {
 
 /**
  * One actionable item extracted by the summarizer.
- * 
+ *
  * `owner` and `due` are best-effort; the LLM may leave either as
  * `None` when the transcript doesn't pin them down. The UI renders
  * them with sensible placeholders ("unassigned", "no due date") so
  * the summary remains useful even when partial.
  */
-export type ActionItem = { 
+export type ActionItem = {
 /**
  * What needs to be done. Required — an action item without a
  * task is meaningless.
  */
-task: string; 
+task: string;
 /**
  * Who is on the hook. `None` when the transcript doesn't say.
  */
-owner?: string | null; 
+owner?: string | null;
 /**
  * Free-form deadline as the LLM extracted it ("Friday", "next
  * sprint", "2026-05-01"). Kept as a string on purpose — parsing
@@ -274,9 +274,9 @@ due?: string | null }
  * Events the use case streams back to the caller. The discriminator
  * is on `kind` (camelCase for the IPC wire format) so the React layer
  * can `switch (event.kind)` directly.
- * 
+ *
  * Variant order:
- * 
+ *
  * 1. Exactly one [`Started`](Self::Started) at the top of the
  * stream, carrying the model id for provenance.
  * 2. Zero or more [`Token`](Self::Token) deltas — one per logical
@@ -286,24 +286,24 @@ due?: string | null }
  * [`Failed`](Self::Failed) if the adapter raised an error
  * mid-stream.
  */
-export type AskAboutMeetingEvent = 
+export type AskAboutMeetingEvent =
 /**
  * Stream is open; the model is about to start emitting tokens.
  * Carries the model id so the UI can show "powered by …" and so
  * chat-history persistence can stamp the right provenance.
  */
-{ kind: "started"; model: string } | 
+{ kind: "started"; model: string } |
 /**
  * One incremental piece of the model's reply. Forwarded verbatim
  * from [`echo_domain::ChatToken::delta`].
  */
-{ kind: "token"; delta: string } | 
+{ kind: "token"; delta: string } |
 /**
  * Stream completed normally. Carries the full assembled reply and
  * the citations parsed from it (deduplicated, validated against
  * the meeting's real segment ids).
  */
-{ kind: "finished"; text: string; citations: SegmentId[]; hadCitations: boolean } | 
+{ kind: "finished"; text: string; citations: SegmentId[]; hadCitations: boolean } |
 /**
  * The adapter raised an error after the stream had already
  * started. The IPC layer SHOULD treat this as a final event and
@@ -312,34 +312,34 @@ export type AskAboutMeetingEvent =
 { kind: "failed"; error: string }
 /**
  * Sample-rate / channel configuration of a stream.
- * 
+ *
  * Wire format uses `camelCase` so the JSON that crosses the Tauri /
  * CLI boundary matches the TypeScript `AudioFormat` (`sampleRateHz`,
  * `channels`). SQLite persistence uses dedicated columns and does
  * not go through serde, so this rename is purely an IPC concern.
  */
-export type AudioFormat = { 
+export type AudioFormat = {
 /**
  * Sampling frequency in hertz.
  */
-sampleRateHz: number; 
+sampleRateHz: number;
 /**
  * Number of interleaved channels (1 = mono, 2 = stereo, ...).
  */
 channels: number }
 /**
  * A single message inside a [`ChatRequest`].
- * 
+ *
  * `content` is plain UTF-8 text — adapters that need a different chat
  * template format (Qwen's `<|im_start|>system\n…<|im_end|>`, Llama's
  * `[INST] … [/INST]`, …) wrap each `ChatMessage` accordingly. The
  * domain layer stays template-agnostic.
  */
-export type ChatMessage = { 
+export type ChatMessage = {
 /**
  * Who authored this message.
  */
-role: ChatRole; 
+role: ChatRole;
 /**
  * Plain-text content. Empty strings are tolerated (the use case
  * occasionally sends empty assistant messages to "prime" the
@@ -348,23 +348,23 @@ role: ChatRole;
 content: string }
 /**
  * Author of a single message in a chat exchange.
- * 
+ *
  * The three roles mirror the OpenAI / llama.cpp chat-template
  * vocabulary exactly so the adapter can fold them into `<|im_start|>`,
  * `<s>[INST]` or any other model-specific framing without translation
  * tables.
  */
-export type ChatRole = 
+export type ChatRole =
 /**
  * Top-of-conversation instructions — typically the transcript
  * excerpt and the "you are a helpful assistant…" preamble.
  * At most one per request, conventionally the first message.
  */
-"system" | 
+"system" |
 /**
  * A turn authored by the human user.
  */
-"user" | 
+"user" |
 /**
  * A turn authored by the model in a previous round of the same
  * conversation. Re-fed verbatim so the model can stay coherent
@@ -375,11 +375,11 @@ export type ChatRole =
  * A term/definition pair extracted from a lecture or class
 
  */
-export type Definition = { 
+export type Definition = {
 /**
  * The term being defined.
  */
-term: string; 
+term: string;
 /**
  * The definition provided.
  */
@@ -387,71 +387,71 @@ definition: string }
 /**
  * Progress events streamed to the frontend during a download.
  */
-export type DownloadEvent = 
+export type DownloadEvent =
 /**
  * Periodic progress update.
  */
-{ kind: "progress"; downloaded: number; total: number } | 
+{ kind: "progress"; downloaded: number; total: number } |
 /**
  * Download finished successfully.
  */
-{ kind: "finished" } | 
+{ kind: "finished" } |
 /**
  * Download failed.
  */
 { kind: "failed"; error: string }
 /**
  * Machine-readable error codes the frontend can match on.
- * 
+ *
  * Kept intentionally coarse — add variants when the frontend needs
  * to distinguish a new failure mode, not for every conceivable
  * backend error.
  */
-export type ErrorCode = 
+export type ErrorCode =
 /**
  * A required record (meeting, speaker, segment, …) was not found.
  */
-"notFound" | 
+"notFound" |
 /**
  * Persistent storage failed (SQLite I/O, migration, …).
  */
-"storage" | 
+"storage" |
 /**
  * The local LLM could not load or inference failed.
  */
-"llm" | 
+"llm" |
 /**
  * The ASR engine could not load or transcription failed.
  */
-"asr" | 
+"asr" |
 /**
  * Input validation failed (empty question, bad template, …).
  */
-"invalidInput" | 
+"invalidInput" |
 /**
  * A streaming session conflict (poisoned map, duplicate id, …).
  */
-"sessionConflict" | 
+"sessionConflict" |
 /**
  * A required model is not downloaded yet.
  */
-"modelNotReady" | 
+"modelNotReady" |
 /**
  * Audio capture or device error.
  */
-"audio" | 
+"audio" |
 /**
  * Voice activity detection failed.
  */
-"vad" | 
+"vad" |
 /**
  * Speaker diarization failed.
  */
-"diarization" | 
+"diarization" |
 /**
  * An HTTP / network operation failed (model download, …).
  */
-"network" | 
+"network" |
 /**
  * Catch-all for unexpected / unclassified errors.
  */
@@ -463,19 +463,19 @@ export type ExportFormat = "markdown" | "txt"
 /**
  * Result returned by [`health_check`]. Mirrors `HealthStatus` on the TS side.
  */
-export type HealthStatus = { 
+export type HealthStatus = {
 /**
  * RFC 3339 timestamp of the probe.
  */
-timestamp: string; 
+timestamp: string;
 /**
  * Backend semver, from Cargo at compile time.
  */
-version: string; 
+version: string;
 /**
  * Target triple the backend was compiled for.
  */
-target: string; 
+target: string;
 /**
  * Short git hash, `unknown` when `.git` is missing at build time.
  */
@@ -484,15 +484,15 @@ commit: string }
  * A notable quote attributed to a speaker, used by the Interview
  * template.
  */
-export type InterviewQuote = { 
+export type InterviewQuote = {
 /**
  * Who said it.
  */
-speaker: string; 
+speaker: string;
 /**
  * Verbatim or near-verbatim quote.
  */
-quote: string; 
+quote: string;
 /**
  * Situational context around the quote.
  */
@@ -502,18 +502,18 @@ context?: string | null }
  * so the frontend stays stylistically consistent (the domain enum
  * uses snake_case for storage / CLI compatibility).
  */
-export type IpcAudioSource = 
+export type IpcAudioSource =
 /**
  * Default microphone via cpal.
  */
-"microphone" | 
+"microphone" |
 /**
  * System audio loopback (macOS 13+ via ScreenCaptureKit).
  */
 "systemOutput"
 /**
  * Structured error returned by every Tauri command.
- * 
+ *
  * Serializes to `{ "code": "notFound", "message": "…", "retriable": false }`
  * on the IPC wire, which the frontend's `useIpcAction` hook can
  * destructure for precise UX.
@@ -523,51 +523,51 @@ export type IpcError = { code: ErrorCode; message: string; retriable: boolean }
  * Full meeting aggregate. Returned by point lookups and includes the
  * segment list and any diarized speakers.
  */
-export type Meeting = 
+export type Meeting =
 /**
  * Summary projection.
  */
-({ 
+({
 /**
  * Stable identifier.
  */
-id: MeetingId; 
+id: MeetingId;
 /**
  * Human-readable title. Defaults to `"Meeting <date>"` when the
  * caller does not supply one.
  */
-title: string; 
+title: string;
 /**
  * RFC 3339 instant the recording started.
  */
-startedAt: string; 
+startedAt: string;
 /**
  * RFC 3339 instant the recording stopped. `None` while the
  * session is still running.
  */
-endedAt: string | null; 
+endedAt: string | null;
 /**
  * Total audio captured, in milliseconds.
  */
-durationMs: number; 
+durationMs: number;
 /**
  * Dominant language reported by the ASR backend (mode of
  * per-chunk languages). `None` until the first chunk lands.
  */
-language: string | null; 
+language: string | null;
 /**
  * Number of segments persisted.
  */
-segmentCount: number }) & { 
+segmentCount: number }) & {
 /**
  * Audio format negotiated with the device.
  */
-inputFormat: AudioFormat; 
+inputFormat: AudioFormat;
 /**
  * Decoded segments, ordered by `start_ms`. Each segment may
  * reference a `speaker_id` from `speakers`.
  */
-segments: Segment[]; 
+segments: Segment[];
 /**
  * Diarized speakers persisted for this meeting, ordered by
  * `slot`. Empty when no diarizer was wired into the pipeline.
@@ -588,19 +588,19 @@ export type MeetingId = string
  * boundaries are decided by SQLite's `snippet()` function and use
  * the markers chosen by the storage adapter — typically `<mark>` /
  * `</mark>` so the UI can render them as highlights.
- * 
+ *
  * `serde(rename_all = "camelCase")` keeps the wire format aligned
  * with the rest of the IPC surface.
  */
-export type MeetingSearchHit = { 
+export type MeetingSearchHit = {
 /**
  * Meeting matched by the query.
  */
-meeting: MeetingSummary; 
+meeting: MeetingSummary;
 /**
  * Highlighted excerpt of the segment that matched.
  */
-snippet: string; 
+snippet: string;
 /**
  * FTS5 BM25 rank — *smaller is better* (negative numbers are
  * strongest matches). The UI should sort ascending; tests assert
@@ -612,34 +612,34 @@ rank: number }
  * Lightweight projection used by listing endpoints. Holds only what
  * the UI needs to render a row in the sidebar — *not* the segments.
  */
-export type MeetingSummary = { 
+export type MeetingSummary = {
 /**
  * Stable identifier.
  */
-id: MeetingId; 
+id: MeetingId;
 /**
  * Human-readable title. Defaults to `"Meeting <date>"` when the
  * caller does not supply one.
  */
-title: string; 
+title: string;
 /**
  * RFC 3339 instant the recording started.
  */
-startedAt: string; 
+startedAt: string;
 /**
  * RFC 3339 instant the recording stopped. `None` while the
  * session is still running.
  */
-endedAt: string | null; 
+endedAt: string | null;
 /**
  * Total audio captured, in milliseconds.
  */
-durationMs: number; 
+durationMs: number;
 /**
  * Dominant language reported by the ASR backend (mode of
  * per-chunk languages). `None` until the first chunk lands.
  */
-language: string | null; 
+language: string | null;
 /**
  * Number of segments persisted.
  */
@@ -647,59 +647,59 @@ segmentCount: number }
 /**
  * A downloadable model known to the app.
  */
-export type ModelInfo = { 
+export type ModelInfo = {
 /**
  * Machine-readable id (e.g. `"asr-large-v3-turbo"`).
  */
-id: string; 
+id: string;
 /**
  * Human label shown in the UI.
  */
-label: string; 
+label: string;
 /**
  * Category: `"asr"`, `"llm"`, `"vad"`, or `"embedder"`.
  */
-kind: string; 
+kind: string;
 /**
  * Whether the file exists on disk right now.
  */
-present: boolean; 
+present: boolean;
 /**
  * Approximate download size in bytes (for progress UI).
  */
 sizeBytes: number }
 /**
  * One contiguous transcription span.
- * 
+ *
  * `serde(rename_all = "camelCase")` keeps the wire format aligned
  * with the TypeScript `Segment` type in `src/types/segment.ts`, so
  * the `Meeting` aggregate returned by `get_meeting` exposes
  * `startMs` (not `start_ms`) — the same convention the streaming
  * `Chunk` event already uses for the segments it carries.
  */
-export type Segment = { 
+export type Segment = {
 /**
  * Stable identifier.
  */
-id: SegmentId; 
+id: SegmentId;
 /**
  * Inclusive start offset, in milliseconds, relative to the
  * containing recording.
  */
-startMs: number; 
+startMs: number;
 /**
  * Exclusive end offset, in milliseconds. Always `>= start_ms`.
  */
-endMs: number; 
+endMs: number;
 /**
  * Decoded text. May be empty when the segment is silence or pure
  * non-speech but the ASR backend still emitted it.
  */
-text: string; 
+text: string;
 /**
  * Diarized speaker. `None` until diarization runs (Sprint 2).
  */
-speakerId: SpeakerId | null; 
+speakerId: SpeakerId | null;
 /**
  * Confidence in `[0.0, 1.0]`. `None` when the backend does not
  * report it (e.g. whisper.cpp without `temperature_inc`).
@@ -713,23 +713,23 @@ confidence: number | null }
 export type SegmentId = string
 /**
  * One clustered voice within a meeting.
- * 
+ *
  * `slot` is the 0-based index of the speaker within the meeting,
  * assigned in arrival order. It drives the UI palette and the
  * default display name; it is **not** the database primary key
  * (that's [`SpeakerId`]).
  */
-export type Speaker = { 
+export type Speaker = {
 /**
  * Stable identifier.
  */
-id: SpeakerId; 
+id: SpeakerId;
 /**
  * 0-based arrival order within the meeting. Drives the default
  * display name (`Speaker 1` for slot 0, etc.) and the color
  * palette index in the UI.
  */
-slot: number; 
+slot: number;
 /**
  * User-assigned label, if any. `None` ⇒ render as
  * "Speaker {slot+1}". Limited to 80 characters at the storage
@@ -745,31 +745,31 @@ export type SpeakerId = string
  * Options the frontend may pass when starting a streaming session.
  * All fields optional; defaults match `StreamingOptions::default()`.
  */
-export type StartStreamingOptions = { 
+export type StartStreamingOptions = {
 /**
  * Capture source. `None` ⇒ microphone, preserving Sprint 0
  * behavior. `systemOutput` requires macOS 13+ with Screen
  * Recording permission (Sprint 1 day 2/3).
  */
-source: IpcAudioSource | null; 
+source: IpcAudioSource | null;
 /**
  * ISO-639-1 language hint. `None` ⇒ auto-detect.
  */
-language: string | null; 
+language: string | null;
 /**
  * Capture device id. `None` ⇒ system default microphone. Ignored
  * when `source = systemOutput`.
  */
-deviceId: string | null; 
+deviceId: string | null;
 /**
  * Audio chunk size in milliseconds. `None` ⇒ 5000.
  */
-chunkMs: number | null; 
+chunkMs: number | null;
 /**
  * RMS threshold below which a chunk is reported as `Skipped`
  * instead of being sent to the ASR. `None` ⇒ 0.02.
  */
-silenceRmsThreshold: number | null; 
+silenceRmsThreshold: number | null;
 /**
  * Enable speaker diarization for this session. `None`/`false` ⇒
  * disabled (keeps Sprint 0 behaviour). When enabled the backend
@@ -778,13 +778,13 @@ silenceRmsThreshold: number | null;
  * so every emitted `Chunk` event carries `speakerId` +
  * `speakerSlot` and the meeting persists its speakers.
  */
-diarize: boolean | null; 
+diarize: boolean | null;
 /**
  * Override path to the speaker-embedder ONNX. `None` ⇒ use the
  * path resolved at app start. Mostly useful for tests / power
  * users; the UI does not surface it.
  */
-embedModelPath: string | null; 
+embedModelPath: string | null;
 /**
  * Disable the neural (Silero) VAD for this session and fall back
  * to the energy-based RMS gate. `None`/`false` ⇒ neural VAD is
@@ -802,14 +802,14 @@ disableNeuralVad: boolean | null }
 export type StreamingSessionId = string
 /**
  * A persisted LLM summary attached to a [`crate::Meeting`].
- * 
+ *
  * `serde(rename_all = "camelCase")` so the React layer can consume
  * `meetingId` / `createdAt` directly. The `content` field flattens
  * the [`SummaryContent`] enum so JSON readers see one combined
  * document instead of `{ "content": { … } }`, matching how the LLM
  * itself emits the structured output.
  */
-export type Summary = 
+export type Summary =
 /**
  * Structured payload — discriminated on `template`.
  */
@@ -817,54 +817,54 @@ export type Summary =
 /**
  * Default template — works for any meeting type (§3.2.1).
  */
-{ template: "general"; summary: string; key_points?: string[]; decisions?: string[]; action_items?: ActionItem[]; open_questions?: string[] } | 
+{ template: "general"; summary: string; key_points?: string[]; decisions?: string[]; action_items?: ActionItem[]; open_questions?: string[] } |
 /**
  * 1:1 meetings between manager and report (§3.2.2).
  */
-{ template: "oneOnOne"; summary: string; wins?: string[]; blockers?: string[]; growth_feedback?: string[]; next_steps?: ActionItem[]; follow_up_topics?: string[] } | 
+{ template: "oneOnOne"; summary: string; wins?: string[]; blockers?: string[]; growth_feedback?: string[]; next_steps?: ActionItem[]; follow_up_topics?: string[] } |
 /**
  * Sprint review / retrospective (§3.2.3).
  */
-{ template: "sprintReview"; summary: string; completed_items?: string[]; carry_over?: string[]; risks?: string[]; next_sprint_priorities?: string[] } | 
+{ template: "sprintReview"; summary: string; completed_items?: string[]; carry_over?: string[]; risks?: string[]; next_sprint_priorities?: string[] } |
 /**
  * User research or hiring interview (§3.2.4).
  */
-{ template: "interview"; summary: string; quotes?: InterviewQuote[]; themes?: string[]; pain_points?: string[]; opportunities?: string[] } | 
+{ template: "interview"; summary: string; quotes?: InterviewQuote[]; themes?: string[]; pain_points?: string[]; opportunities?: string[] } |
 /**
  * Sales / discovery call (§3.2.5).
  */
-{ template: "salesCall"; summary: string; customer_context?: string | null; pain_points?: string[]; interest_signals?: string[]; objections?: string[]; next_steps?: ActionItem[]; deal_stage_indicator?: string | null } | 
+{ template: "salesCall"; summary: string; customer_context?: string | null; pain_points?: string[]; interest_signals?: string[]; objections?: string[]; next_steps?: ActionItem[]; deal_stage_indicator?: string | null } |
 /**
  * Lecture, class, or workshop (§3.2.6).
  */
-{ template: "lecture"; summary: string; concepts_covered?: string[]; definitions?: Definition[]; examples?: string[]; homework_or_next?: string[] } | 
+{ template: "lecture"; summary: string; concepts_covered?: string[]; definitions?: Definition[]; examples?: string[]; homework_or_next?: string[] } |
 /**
  * Graceful degradation when JSON parsing fails twice.
  */
-{ template: "freeText"; text: string }) & { 
+{ template: "freeText"; text: string }) & {
 /**
  * Stable identifier.
  */
-id: SummaryId; 
+id: SummaryId;
 /**
  * Owning meeting. Each meeting may carry at most one summary
  * per template at a time — re-running the summarizer
  * overwrites the previous one (the SQLite adapter enforces
  * this with a unique index).
  */
-meetingId: MeetingId; 
+meetingId: MeetingId;
 /**
  * LLM model identifier (e.g. `"qwen2.5-7b-instruct-q4_k_m"`).
  * Stored alongside the content so a future "regenerate with
  * model X" flow can compare provenance.
  */
-model: string; 
+model: string;
 /**
  * ISO-639-1 language the summary was produced in. Echoes the
  * transcript's dominant language; the LLM is instructed to
  * answer in that language.
  */
-language: string | null; 
+language: string | null;
 /**
  * RFC 3339 instant the summary finished generating.
  */
@@ -877,33 +877,33 @@ createdAt: string }
 export type SummaryId = string
 /**
  * One event emitted by the streaming pipeline.
- * 
+ *
  * The variant order on the wire intentionally matches the lifecycle:
  * `Started` → 0..N × `Chunk` → optional `Skipped` mixed in →
  * `Stopped` | `Failed`.
- * 
+ *
  * Wire format: tagged with `type` (lowercase) and field names in
  * `camelCase` for ergonomic consumption from TypeScript.
  */
-export type TranscriptEvent = 
+export type TranscriptEvent =
 /**
  * Capture has begun. Reports the negotiated input format.
  */
-{ type: "started"; sessionId: StreamingSessionId; inputFormat: AudioFormat } | 
+{ type: "started"; sessionId: StreamingSessionId; inputFormat: AudioFormat } |
 /**
  * One transcribed chunk. Segments inside are timestamped relative
  * to the start of the session (not the chunk).
  */
-{ type: "chunk"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; segments: Segment[]; language: string | null; rtf: number; speakerId?: SpeakerId | null; speakerSlot?: number | null } | 
+{ type: "chunk"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; segments: Segment[]; language: string | null; rtf: number; speakerId?: SpeakerId | null; speakerSlot?: number | null } |
 /**
  * A chunk was discarded by the silence gate before being sent to
  * the ASR backend. Useful for UI / metrics.
  */
-{ type: "skipped"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; durationMs: number; rms: number } | 
+{ type: "skipped"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; durationMs: number; rms: number } |
 /**
  * The pipeline finished cleanly (caller stopped or stream EOF).
  */
-{ type: "stopped"; sessionId: StreamingSessionId; totalSegments: number; totalAudioMs: number } | 
+{ type: "stopped"; sessionId: StreamingSessionId; totalSegments: number; totalAudioMs: number } |
 /**
  * The pipeline aborted with an error. No further events follow.
  */

--- a/src/ipc/client.ts
+++ b/src/ipc/client.ts
@@ -214,6 +214,16 @@ export async function downloadModel(
   return invoke<void>("download_model", { modelId, onEvent: channel });
 }
 
+/** Cancel an in-flight model download. Returns true if a download was found. */
+export async function cancelDownload(modelId: string): Promise<boolean> {
+  return invoke<boolean>("cancel_download", { modelId });
+}
+
+/** Delete a downloaded model from disk. */
+export async function deleteModel(modelId: string): Promise<void> {
+  return invoke<void>("delete_model", { modelId });
+}
+
 // ---------------------------------------------------------------------------
 // Chat with transcript (Sprint 1 day 10 — CU-05)
 // ---------------------------------------------------------------------------

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -11,4 +11,5 @@ export type ModelInfo = {
 export type DownloadEvent =
   | { kind: "progress"; downloaded: number; total: number }
   | { kind: "finished" }
-  | { kind: "failed"; error: string };
+  | { kind: "failed"; error: string }
+  | { kind: "cancelled" };


### PR DESCRIPTION
## Summary

Add the ability to cancel an in-progress model download and delete installed models from disk.

## Backend (Rust)

- **`cancel_download` command** — Sets an `AtomicBool` cancel flag checked each chunk in the download loop. Cleans up the `.part` temp file and sends a `Cancelled` event.
- **`delete_model` command** — Unloads the model from memory (if loaded), then removes the file from disk.
- **`Cancelled` variant** added to `DownloadEvent` enum.
- Changed `in_flight_downloads` from `HashSet<String>` to `HashMap<String, Arc<AtomicBool>>` to store per-download cancel signals.

## Frontend (TypeScript/React)

- Added `cancelDownload()` and `deleteModel()` IPC client functions.
- Extended `useModelManager` hook with `cancelDl` and `remove` callbacks.
- **UI**: Cancel button (red) appears during download; trash icon next to "Installed" badge for deletion.
- Added i18n keys (`models.cancel`, `models.delete`) in English and Spanish.

## Bug Fixes (included)

- Fix `[object Object]` error display in `useRecordingSession` catch blocks (IpcError handling).
- Set `minimumSystemVersion: "11.0"` in `tauri.conf.json` for `std::filesystem` compatibility.

## Files Changed

| Layer | Files |
|-------|-------|
| Rust backend | `commands/mod.rs`, `commands/models.rs`, `lib.rs` |
| TS types | `types/models.ts` |
| IPC | `ipc/client.ts`, `ipc/bindings.ts` |
| Hook | `hooks/useModelManager.ts`, `hooks/useRecordingSession.ts` |
| UI | `features/settings/ModelManager.tsx` |
| i18n | `locales/en.json`, `locales/es.json` |
| Config | `tauri.conf.json` |

## Testing

- `cargo check -p echo-shell` passes (exit 0)
- `pnpm tauri build` DMG build succeeds (exit 0)