### PR TITLE
fix: use app data dir for model paths in production builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
+        check-latest: true
         cache: pnpm
 
     - name: pnpm install (frozen lockfile)
@@ -165,6 +166,7 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
+        check-latest: true
         cache: pnpm
 
     - name: pnpm install (frozen lockfile)
@@ -202,6 +204,7 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
+        check-latest: true
         cache: pnpm
 
     - name: pnpm install (frozen lockfile)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Cache cargo registry and target
       uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
       with:
-        shared-key: release-${{ matrix.label }}
+        shared-key: release-${{ matrix.label }}-v2
 
     # --- Linux system deps ---
     - name: Install system dependencies (Linux)
@@ -118,6 +118,7 @@ jobs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
+        check-latest: true
         cache: pnpm
 
     - name: pnpm install

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -868,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1263,7 +1263,7 @@ checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "echo-app"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "echo-asr"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "echo-audio"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "cpal",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "echo-diarize"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "echo-domain"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "echo-llm"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "echo-proto"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "echo-shell"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "dirs",
  "echo-app",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "echo-storage"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "echo-telemetry"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1464,14 +1464,14 @@ dependencies = [
 
 [[package]]
 name = "embed-resource"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
+checksum = "c31a88c8d26de40ed18fe748c547845aa39de1db3afd958f8cb91579f3644bcb"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -2907,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -3028,9 +3028,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.144"
+version = "0.1.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2e7a3cc3ed741aa3d5e6e3ff1d84d5ab7ba13bf15c857be06a5d11517767616"
+checksum = "2e82b8c7a1c1a0ad97e1cc5cc28e01e9e14be73d4068e0fe9ac9d6c465001323"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.144"
+version = "0.1.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2efa5c5675f4e2170c52c4418f71907d39b1e3931fd7566f8382cf9e166282"
+checksum = "9e1e5495433ca7487b9f8c7046f64e69937861d438b20f12ee3c524f35d55ad3"
 dependencies = [
  "bindgen",
  "cc",
@@ -4892,9 +4892,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6545,6 +6545,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6604,7 +6619,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6613,7 +6628,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6918,9 +6933,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -7316,9 +7331,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
@@ -8013,9 +8028,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 # Shared package metadata inherited by member crates via `package.xxx.workspace = true`
 # -----------------------------------------------------------------------------
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Luis MC <luismctechdev@gmail.com>"]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -21,7 +21,7 @@ pub mod streaming;
 // sub-modules directly: `commands::streaming::start_streaming`, etc.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
@@ -154,6 +154,11 @@ pub struct AppState {
     /// Model IDs currently being downloaded, mapped to a cancel flag.
     /// Setting the flag to `true` signals the download loop to abort.
     pub(crate) in_flight_downloads: Arc<Mutex<std::collections::HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>>>,
+    /// Root directory for model files and other data assets.
+    /// In debug builds this is the workspace root; in release builds
+    /// it falls back to the Tauri `appDataDir` so models are
+    /// downloaded to a writable, OS-standard location.
+    pub(crate) data_root: PathBuf,
 }
 
 use echo_domain::StreamingSessionId;
@@ -203,15 +208,27 @@ impl AppState {
     /// Build the shared state. Async because opening the SQLite database
     /// runs migrations, which is I/O.
     pub async fn initialize(app_data_dir: Option<PathBuf>) -> Result<Self, IpcError> {
+        // In release builds prefer the Tauri app-data directory so
+        // downloaded models land in an OS-writable location instead of
+        // the (non-existent) compile-time source tree.
+        let data_root = if cfg!(debug_assertions) {
+            workspace_root()
+        } else {
+            app_data_dir.clone().unwrap_or_else(workspace_root)
+        };
+        tracing::info!(data_root = %data_root.display(), "resolved data root for model assets");
+
         let model_path =
-            resolve_asset_path(std::env::var("ECHO_ASR_MODEL").ok(), preferred_asr_model());
+            resolve_asset_path(&data_root, std::env::var("ECHO_ASR_MODEL").ok(), preferred_asr_model(&data_root));
         let embed_model_path = resolve_asset_path(
+            &data_root,
             std::env::var("ECHO_EMBED_MODEL").ok(),
             "models/embedder/eres2net_en_voxceleb.onnx",
         );
         let llm_model_path =
-            resolve_asset_path(std::env::var("ECHO_LLM_MODEL").ok(), preferred_llm_model());
+            resolve_asset_path(&data_root, std::env::var("ECHO_LLM_MODEL").ok(), preferred_llm_model(&data_root));
         let vad_model_path = resolve_asset_path(
+            &data_root,
             std::env::var("ECHO_VAD_MODEL").ok(),
             "models/vad/silero_vad.onnx",
         );
@@ -249,6 +266,7 @@ impl AppState {
             vad_model_path,
             vad: LazyModel::new(),
             in_flight_downloads: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            data_root,
         })
     }
 
@@ -259,14 +277,16 @@ impl AppState {
     /// Lazily load the local LLM (concrete type for adapters).
     pub(crate) async fn ensure_llm_concrete(&self) -> Result<Arc<LlamaCppLlm>, IpcError> {
         let model_path = self.llm_model_path.clone();
+        let data_root = self.data_root.clone();
         self.llm
             .get_or_init(|| async move {
                 let path = if model_path.exists() {
                     model_path.clone()
                 } else {
                     let fresh = resolve_asset_path(
+                        &data_root,
                         std::env::var("ECHO_LLM_MODEL").ok(),
-                        preferred_llm_model(),
+                        preferred_llm_model(&data_root),
                     );
                     if !fresh.exists() {
                         return Err(IpcError::model_not_ready(format!(
@@ -377,14 +397,16 @@ impl AppState {
     /// Lazily load the whisper transcriber.
     pub(crate) async fn ensure_transcriber(&self) -> Result<Arc<dyn Transcriber>, IpcError> {
         let asr_path = self.model_path.clone();
+        let data_root = self.data_root.clone();
         self.transcriber
             .get_or_init(|| async move {
                 let path = if asr_path.exists() {
                     asr_path.clone()
                 } else {
                     let fresh = resolve_asset_path(
+                        &data_root,
                         std::env::var("ECHO_ASR_MODEL").ok(),
-                        preferred_asr_model(),
+                        preferred_asr_model(&data_root),
                     );
                     if !fresh.exists() {
                         return Err(IpcError::model_not_ready(format!(
@@ -440,7 +462,7 @@ fn resolve_db_path(app_data_dir: Option<PathBuf>) -> PathBuf {
     workspace_root().join("echonote.db")
 }
 
-fn preferred_llm_model() -> &'static str {
+fn preferred_llm_model(root: &Path) -> &'static str {
     const CANDIDATES: &[&str] = &[
         "models/llm/Qwen3-30B-A3B-Q4_K_M.gguf",
         "models/llm/Qwen3-14B-Q4_K_M.gguf",
@@ -448,7 +470,6 @@ fn preferred_llm_model() -> &'static str {
         "models/llm/qwen2.5-7b-instruct-q4_k_m.gguf",
         "models/llm/qwen2.5-3b-instruct-q4_k_m.gguf",
     ];
-    let root = workspace_root();
     for rel in CANDIDATES {
         if root.join(rel).exists() {
             return rel;
@@ -457,7 +478,7 @@ fn preferred_llm_model() -> &'static str {
     "models/llm/Qwen3-14B-Q4_K_M.gguf"
 }
 
-fn preferred_asr_model() -> &'static str {
+fn preferred_asr_model(root: &Path) -> &'static str {
     const CANDIDATES: &[&str] = &[
         "models/asr/ggml-large-v3-turbo-es.bin",
         "models/asr/ggml-large-v3-turbo.bin",
@@ -472,7 +493,6 @@ fn preferred_asr_model() -> &'static str {
         "models/asr/ggml-small.en.bin",
         "models/asr/ggml-tiny.en.bin",
     ];
-    let root = workspace_root();
     for rel in CANDIDATES {
         if root.join(rel).exists() {
             return rel;
@@ -481,26 +501,20 @@ fn preferred_asr_model() -> &'static str {
     "models/asr/ggml-large-v3-turbo.bin"
 }
 
-fn resolve_asset_path(override_value: Option<String>, default_relative: &str) -> PathBuf {
-    let workspace_root = workspace_root();
-
+fn resolve_asset_path(root: &Path, override_value: Option<String>, default_relative: &str) -> PathBuf {
     if let Some(raw) = override_value.filter(|s| !s.trim().is_empty()) {
         let raw_path = PathBuf::from(&raw);
         if raw_path.is_absolute() {
             return raw_path;
         }
-        let rooted = workspace_root.join(&raw_path);
+        let rooted = root.join(&raw_path);
         if rooted.exists() {
             return rooted;
         }
         return raw_path;
     }
 
-    let rooted = workspace_root.join(default_relative);
-    if rooted.exists() {
-        return rooted;
-    }
-    rooted
+    root.join(default_relative)
 }
 
 /// Best-effort workspace root: the directory above `src-tauri/`.

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -8,7 +8,7 @@ use crate::ipc_error::{ErrorCode, IpcError};
 
 use futures::stream::StreamExt;
 
-use super::{workspace_root, AppState};
+use super::AppState;
 
 /// A downloadable model known to the app.
 #[derive(Debug, Clone, Serialize, specta::Type)]
@@ -32,8 +32,7 @@ pub struct ModelInfo {
 /// Each entry carries an optional SHA-256 hex digest. When present,
 /// downloads are verified after completion and rejected on mismatch.
 /// Populate hashes by running `shasum -a 256 <model_file>`.
-fn model_catalog() -> Vec<(ModelInfo, &'static str, Option<&'static str>)> {
-    let root = workspace_root();
+fn model_catalog(root: &std::path::Path) -> Vec<(ModelInfo, &'static str, Option<&'static str>)> {
     let present = |rel: &str| root.join(rel).exists();
 
     vec![
@@ -158,8 +157,8 @@ fn model_dest_path(id: &str) -> Option<&'static str> {
 /// Return the status of all downloadable models.
 #[tauri::command]
 #[specta::specta]
-pub fn get_model_status() -> Vec<ModelInfo> {
-    model_catalog()
+pub fn get_model_status(state: State<'_, AppState>) -> Vec<ModelInfo> {
+    model_catalog(&state.data_root)
         .into_iter()
         .map(|(info, _, _)| info)
         .collect()
@@ -219,7 +218,7 @@ pub async fn download_model(
         }
     });
 
-    let catalog = model_catalog();
+    let catalog = model_catalog(&state.data_root);
     let (_, url, expected_sha) = catalog
         .iter()
         .find(|(info, _, _)| info.id == model_id)
@@ -229,7 +228,7 @@ pub async fn download_model(
 
     let rel_path = model_dest_path(&model_id)
         .ok_or_else(|| IpcError::not_found(format!("no dest path for model: {model_id}")))?;
-    let dest = workspace_root().join(rel_path);
+    let dest = state.data_root.join(rel_path);
 
     if let Some(parent) = dest.parent() {
         tokio::fs::create_dir_all(parent)
@@ -372,7 +371,7 @@ pub async fn delete_model(
 ) -> Result<(), IpcError> {
     let rel_path = model_dest_path(&model_id)
         .ok_or_else(|| IpcError::not_found(format!("unknown model: {model_id}")))?;
-    let dest = workspace_root().join(rel_path);
+    let dest = state.data_root.join(rel_path);
 
     if !dest.exists() {
         return Err(IpcError::not_found(format!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "EchoNote",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "app.echonote.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Problem

In release builds, `workspace_root()` resolves to the compile-time source tree path baked via `env!("CARGO_MANIFEST_DIR")`. On the user's machine this path either doesn't exist or isn't writable, causing **"Permission denied (os error 13)"** when downloading models from the Model Manager.

Additionally, CI was failing:
- **macOS**: stale cmake cache prevented `-D_LIBCPP_DISABLE_AVAILABILITY` from taking effect (`std::filesystem::path` unavailable)
- **Windows**: `node:sqlite` not found because pnpm 10.13.1 requires Node ≥ 22.13

## Solution

### Model path fix
- Add `data_root: PathBuf` to `AppState`
  - Release builds → `appDataDir` (e.g. `~/Library/Application Support/com.echonote.app/`)
  - Debug builds → `workspace_root()` (preserves dev ergonomics)
- Update `resolve_asset_path()`, `preferred_asr_model()`, `preferred_llm_model()` to accept `root: &Path`
- Update `model_catalog()`, `download_model()`, `delete_model()`, `get_model_status()` to use `state.data_root`
- Update lazy re-resolvers (`ensure_llm_concrete`, `ensure_transcriber`) to use `data_root`

### CI fixes
- Bump rust-cache shared-key to bust stale cmake caches on macOS
- Add `check-latest: true` to all `setup-node` steps (ensures Node ≥ 22.13 on Windows)

## Version
Bumped to **0.2.1** (patch release).