### PR TITLE
fix(vad): download pre-simplified silero onnx instead of upstream

### DIFF
--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -127,13 +127,15 @@ fn model_catalog(root: &std::path::Path) -> Vec<(ModelInfo, &'static str, Option
         (
             ModelInfo {
                 id: "vad-silero".into(),
-                label: "Silero VAD v5 (2 MB)".into(),
+                label: "Silero VAD v5 (1.2 MB, simplified for tract)".into(),
                 kind: "vad".into(),
                 present: present("models/vad/silero_vad.onnx"),
-                size_bytes: 2_200_000,
+                size_bytes: 1_200_000,
             },
-            "https://github.com/snakers4/silero-vad/raw/v5.1.2/src/silero_vad/data/silero_vad.onnx",
-            None, // TODO: populate sha256
+            // Pre-simplified ONNX (If nodes inlined for 16 kHz, BASIC-optimised).
+            // The upstream file has ONNX `If` ops that tract cannot execute.
+            "https://github.com/luismctech/echonote/releases/download/v0.2.1/silero_vad.onnx",
+            Some("d224cf508fbaf8bb1a49f333120b536dbaa1ed2b0ab49bed059d6e44a4f8305c"),
         ),
     ]
 }


### PR DESCRIPTION
## Problem

Starting a recording in the installed app fails with:

```
failed to load Silero VAD at .../models/vad/silero_vad.onnx:
voice activity detection failed: optimize: Failed analyse for node #5 "If_0" If
```

The download catalog pointed to the **upstream** Silero VAD v5 ONNX which contains `If` operators that `tract-onnx` cannot execute.

## Solution

- Upload the pre-simplified ONNX (produced by `scripts/simplify-silero-vad.py`) as a release asset on v0.2.1
- Point the catalog URL to the hosted simplified model
- Add SHA-256 verification for the download
- Update size to 1.2 MB (was 2.2 MB)