### PR TITLE
feat: add custom summary templates and runtime model selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,8 @@ fixtures/audio/
 # Bench reports
 # -----------------------------------------------------------------------------
 target/bench-reports/
+
+# -----------------------------------------------------------------------------
+# Runtime data (custom templates are stored in app data dir at runtime)
+# -----------------------------------------------------------------------------
+custom_templates.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "echo-app"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1283,7 +1283,7 @@ dependencies = [
 
 [[package]]
 name = "echo-asr"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "echo-audio"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "cpal",
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "echo-diarize"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "echo-domain"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "echo-llm"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "echo-proto"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "echo-shell"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "echo-app",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "echo-storage"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1445,7 +1445,7 @@ dependencies = [
 
 [[package]]
 name = "echo-telemetry"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
 # Shared package metadata inherited by member crates via `package.xxx.workspace = true`
 # -----------------------------------------------------------------------------
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Luis MC <luismctechdev@gmail.com>"]

--- a/crates/echo-app/src/use_cases/generate_summary.rs
+++ b/crates/echo-app/src/use_cases/generate_summary.rs
@@ -25,8 +25,8 @@ use time::OffsetDateTime;
 use tracing::{info, instrument, warn};
 
 use echo_domain::{
-    Definition, DomainError, GenerateOptions, InterviewQuote, LlmModel, Meeting, MeetingId,
-    MeetingStore, Speaker, Summary, SummaryContent, SummaryId, TEMPLATE_IDS,
+    CustomTemplate, Definition, DomainError, GenerateOptions, InterviewQuote, LlmModel, Meeting,
+    MeetingId, MeetingStore, Speaker, Summary, SummaryContent, SummaryId, TEMPLATE_IDS,
 };
 
 /// Maximum characters of transcript text fed to the model. Qwen 3
@@ -179,6 +179,65 @@ impl SummarizeMeeting {
         );
         Ok(summary)
     }
+
+    /// Generate (and persist) a summary using a user-defined
+    /// [`CustomTemplate`]. The LLM output is stored verbatim as
+    /// [`SummaryContent::Custom`] since the output shape is not
+    /// known at compile time.
+    #[instrument(skip(self, custom), fields(meeting_id = %meeting_id, template_name = %custom.name))]
+    pub async fn execute_custom(
+        &self,
+        meeting_id: MeetingId,
+        custom: &CustomTemplate,
+    ) -> Result<Summary, SummarizeMeetingError> {
+        let meeting = self
+            .store
+            .get(meeting_id)
+            .await
+            .map_err(SummarizeMeetingError::Storage)?
+            .ok_or(SummarizeMeetingError::NotFound(meeting_id))?;
+
+        let transcript = render_transcript(&meeting);
+        if transcript.trim().is_empty() {
+            return Err(SummarizeMeetingError::EmptyTranscript(meeting_id));
+        }
+
+        let language = meeting.summary.language.clone();
+        let language_instruction = language_instruction(language.as_deref());
+
+        let prompt = build_custom_prompt(custom, &transcript, &language_instruction);
+        let response = self
+            .llm
+            .generate(&prompt, &generate_opts())
+            .await
+            .map_err(SummarizeMeetingError::Llm)?;
+
+        let content = SummaryContent::Custom {
+            template_name: custom.name.clone(),
+            text: response.trim().to_string(),
+        };
+
+        let summary = Summary {
+            id: SummaryId::new(),
+            meeting_id,
+            model: self.llm.model_id().to_string(),
+            language,
+            created_at: OffsetDateTime::now_utc(),
+            content,
+        };
+
+        self.store
+            .upsert_summary(&summary)
+            .await
+            .map_err(SummarizeMeetingError::Storage)?;
+
+        info!(
+            template_name = %custom.name,
+            model = %summary.model,
+            "custom summary persisted"
+        );
+        Ok(summary)
+    }
 }
 
 /// Default generation knobs for summaries. Low temperature + nucleus
@@ -280,6 +339,30 @@ fn build_prompt(
         schema,
         transcript,
         parser_feedback,
+    )
+}
+
+/// Build a prompt from a user-defined [`CustomTemplate`]. The
+/// user's prompt is used verbatim as the system role (+ language
+/// instruction). The output is free-form text.
+fn build_custom_prompt(
+    custom: &CustomTemplate,
+    transcript: &str,
+    language_instruction: &str,
+) -> String {
+    let system = format!(
+        "{} {language_instruction}\n\
+         Analyze the following meeting transcript and produce your response \
+         according to the instructions above.",
+        custom.prompt,
+    );
+
+    let user = format!("Transcript:\n---\n{transcript}\n---");
+
+    format!(
+        "<|im_start|>system\n{system}<|im_end|>\n\
+         <|im_start|>user\n{user}<|im_end|>\n\
+         <|im_start|>assistant\n"
     )
 }
 

--- a/crates/echo-domain/src/entities/custom_template.rs
+++ b/crates/echo-domain/src/entities/custom_template.rs
@@ -1,0 +1,50 @@
+//! User-defined summary prompt templates.
+//!
+//! A [`CustomTemplate`] lets the user define their own system prompt
+//! (role + instructions) and optionally a JSON schema hint. The LLM
+//! output is stored as [`crate::SummaryContent::Custom`] — free-form
+//! text keyed by the template's id.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Strongly-typed identifier for a [`CustomTemplate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, specta::Type)]
+#[serde(transparent)]
+pub struct CustomTemplateId(pub Uuid);
+
+impl CustomTemplateId {
+    /// Generate a new UUIDv7 identifier.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::now_v7())
+    }
+}
+
+impl Default for CustomTemplateId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for CustomTemplateId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// A user-created summary prompt template.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomTemplate {
+    /// Stable identifier.
+    pub id: CustomTemplateId,
+    /// Short display name shown in the template selector (e.g.
+    /// "Product Standup", "Board Meeting").
+    pub name: String,
+    /// The system-prompt text sent to the LLM. Should describe the
+    /// role, desired output format, and any constraints.
+    /// Example: "You are a product standup summarizer. Output a JSON
+    /// object with keys: blockers, updates, askForHelp."
+    pub prompt: String,
+}

--- a/crates/echo-domain/src/entities/mod.rs
+++ b/crates/echo-domain/src/entities/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! Concrete types are fleshed out in each submodule.
 
+pub mod custom_template;
 pub mod meeting;
 pub mod segment;
 pub mod speaker;

--- a/crates/echo-domain/src/entities/summary.rs
+++ b/crates/echo-domain/src/entities/summary.rs
@@ -241,6 +241,16 @@ pub enum SummaryContent {
         /// Whatever the model produced, verbatim.
         text: String,
     },
+
+    /// User-defined custom template. The `template_name` identifies
+    /// which [`crate::CustomTemplate`] produced this summary.
+    #[serde(rename = "custom")]
+    Custom {
+        /// Display name of the custom template (e.g. "Product Standup").
+        template_name: String,
+        /// The LLM output, stored verbatim.
+        text: String,
+    },
 }
 
 impl SummaryContent {
@@ -257,6 +267,7 @@ impl SummaryContent {
             SummaryContent::SalesCall { .. } => "salesCall",
             SummaryContent::Lecture { .. } => "lecture",
             SummaryContent::FreeText { .. } => "freeText",
+            SummaryContent::Custom { .. } => "custom",
         }
     }
 }

--- a/crates/echo-domain/src/lib.rs
+++ b/crates/echo-domain/src/lib.rs
@@ -32,6 +32,7 @@ pub use ports::resampler::Resampler;
 pub use ports::transcriber::{TranscribeOptions, Transcriber, Transcript};
 pub use ports::vad::{Vad, VoiceState};
 
+pub use entities::custom_template::{CustomTemplate, CustomTemplateId};
 pub use entities::meeting::{Meeting, MeetingId, MeetingSearchHit, MeetingSummary};
 pub use entities::segment::{Segment, SegmentId};
 pub use entities::speaker::{Speaker, SpeakerId};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "echonote",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "Private, local-first meeting transcription and AI summaries.",
   "type": "module",
   "packageManager": "pnpm@10.13.1",

--- a/src-tauri/src/commands/llm.rs
+++ b/src-tauri/src/commands/llm.rs
@@ -6,7 +6,7 @@ use tauri::State;
 use crate::ipc_error::IpcError;
 
 use echo_app::{AskAboutMeeting, AskAboutMeetingEvent, SummarizeMeeting};
-use echo_domain::{ChatMessage, MeetingId, Summary};
+use echo_domain::{ChatMessage, CustomTemplateId, MeetingId, Summary};
 use futures::stream::StreamExt;
 
 use super::AppState;
@@ -48,6 +48,33 @@ pub async fn get_summary(
         .get_summary(meeting_id)
         .await
         .map_err(|e| IpcError::storage(format!("get summary: {e}")))
+}
+
+/// Generate a summary using a user-defined custom template.
+///
+/// Loads the custom template by `template_id`, then runs the LLM with
+/// the user's prompt. The result is stored as
+/// [`echo_domain::SummaryContent::Custom`].
+#[tauri::command]
+#[specta::specta]
+pub async fn summarize_with_custom_template(
+    state: State<'_, AppState>,
+    meeting_id: MeetingId,
+    template_id: CustomTemplateId,
+) -> Result<Summary, IpcError> {
+    // Load the custom template from disk.
+    let templates = super::templates::read_templates_from(&state)?;
+    let custom = templates
+        .iter()
+        .find(|t| t.id == template_id)
+        .ok_or_else(|| IpcError::not_found(format!("custom template {template_id} not found")))?;
+
+    let llm = state.ensure_llm().await?;
+    let use_case = SummarizeMeeting::new(llm, state.store.clone());
+    use_case
+        .execute_custom(meeting_id, custom)
+        .await
+        .map_err(IpcError::from)
 }
 
 /// Run one chat turn against a meeting's transcript.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod llm;
 pub mod meetings;
 pub mod models;
 pub mod streaming;
+pub mod templates;
 
 // Re-export public items for non-macro usage (e.g. `commands::AppState`).
 // The `tauri_specta::collect_commands!` macro in `lib.rs` references
@@ -133,7 +134,9 @@ pub struct AppState {
     pub(crate) resampler: Arc<dyn Resampler>,
     /// Lazily-loaded whisper transcriber (concrete so `LazyModel<T>` stays `Sized`).
     pub(crate) transcriber: LazyModel<WhisperCppTranscriber>,
-    pub(crate) model_path: PathBuf,
+    /// Path to the local ASR model. Behind a `RwLock` so
+    /// `set_active_asr` can switch models at runtime.
+    pub(crate) model_path: std::sync::RwLock<PathBuf>,
     /// Where to find the speaker embedder ONNX.
     pub(crate) embed_model_path: PathBuf,
     pub(crate) store: Arc<dyn MeetingStore>,
@@ -141,8 +144,9 @@ pub struct AppState {
     pub(crate) rename_speaker: Arc<RenameSpeaker>,
     /// In-flight streaming sessions.
     pub(crate) sessions: Arc<Mutex<HashMap<StreamingSessionId, SessionEntry>>>,
-    /// Path to the local LLM (.gguf).
-    pub(crate) llm_model_path: PathBuf,
+    /// Path to the local LLM (.gguf). Behind a `RwLock` so
+    /// `set_active_llm` can switch models at runtime.
+    pub(crate) llm_model_path: std::sync::RwLock<PathBuf>,
     /// Lazily-loaded LLM, held as the concrete [`LlamaCppLlm`] so we
     /// can derive both `LlmModel` and `ChatAssistant` from the same
     /// loaded weights.
@@ -153,7 +157,9 @@ pub struct AppState {
     pub(crate) vad: LazyModel<SileroVad>,
     /// Model IDs currently being downloaded, mapped to a cancel flag.
     /// Setting the flag to `true` signals the download loop to abort.
-    pub(crate) in_flight_downloads: Arc<Mutex<std::collections::HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>>>,
+    pub(crate) in_flight_downloads: Arc<
+        Mutex<std::collections::HashMap<String, std::sync::Arc<std::sync::atomic::AtomicBool>>>,
+    >,
     /// Root directory for model files and other data assets.
     /// In debug builds this is the workspace root; in release builds
     /// it falls back to the Tauri `appDataDir` so models are
@@ -172,6 +178,29 @@ impl AppState {
     /// Cheap clone of the session-map handle.
     pub(crate) fn sessions_handle(&self) -> Arc<Mutex<HashMap<StreamingSessionId, SessionEntry>>> {
         self.sessions.clone()
+    }
+
+    /// Update the LLM model path at runtime. Must be called after
+    /// `llm.unload()` so the next `ensure_llm()` loads the new model.
+    pub(crate) fn set_llm_model_path(&self, path: PathBuf) {
+        *self.llm_model_path.write().unwrap() = path;
+    }
+
+    /// Read the current LLM model path.
+    pub(crate) fn active_llm_path(&self) -> PathBuf {
+        self.llm_model_path.read().unwrap().clone()
+    }
+
+    /// Update the ASR model path at runtime. Must be called after
+    /// `transcriber.unload()` so the next `ensure_transcriber()` loads
+    /// the new model.
+    pub(crate) fn set_asr_model_path(&self, path: PathBuf) {
+        *self.model_path.write().unwrap() = path;
+    }
+
+    /// Read the current ASR model path.
+    pub(crate) fn active_asr_path(&self) -> PathBuf {
+        self.model_path.read().unwrap().clone()
     }
 
     /// Ordered shutdown sequence invoked from the Tauri `Exit` hook.
@@ -218,15 +247,21 @@ impl AppState {
         };
         tracing::info!(data_root = %data_root.display(), "resolved data root for model assets");
 
-        let model_path =
-            resolve_asset_path(&data_root, std::env::var("ECHO_ASR_MODEL").ok(), preferred_asr_model(&data_root));
+        let model_path = resolve_asset_path(
+            &data_root,
+            std::env::var("ECHO_ASR_MODEL").ok(),
+            preferred_asr_model(&data_root),
+        );
         let embed_model_path = resolve_asset_path(
             &data_root,
             std::env::var("ECHO_EMBED_MODEL").ok(),
             "models/embedder/eres2net_en_voxceleb.onnx",
         );
-        let llm_model_path =
-            resolve_asset_path(&data_root, std::env::var("ECHO_LLM_MODEL").ok(), preferred_llm_model(&data_root));
+        let llm_model_path = resolve_asset_path(
+            &data_root,
+            std::env::var("ECHO_LLM_MODEL").ok(),
+            preferred_llm_model(&data_root),
+        );
         let vad_model_path = resolve_asset_path(
             &data_root,
             std::env::var("ECHO_VAD_MODEL").ok(),
@@ -255,13 +290,13 @@ impl AppState {
             capture: Arc::new(RoutingAudioCapture::with_default_adapters()),
             resampler: Arc::new(RubatoResamplerAdapter::new()),
             transcriber: LazyModel::new(),
-            model_path,
+            model_path: std::sync::RwLock::new(model_path),
             embed_model_path,
             store,
             recorder,
             rename_speaker,
             sessions: Arc::new(Mutex::new(HashMap::new())),
-            llm_model_path,
+            llm_model_path: std::sync::RwLock::new(llm_model_path),
             llm: LazyModel::new(),
             vad_model_path,
             vad: LazyModel::new(),
@@ -276,7 +311,7 @@ impl AppState {
 
     /// Lazily load the local LLM (concrete type for adapters).
     pub(crate) async fn ensure_llm_concrete(&self) -> Result<Arc<LlamaCppLlm>, IpcError> {
-        let model_path = self.llm_model_path.clone();
+        let model_path = self.llm_model_path.read().unwrap().clone();
         let data_root = self.data_root.clone();
         self.llm
             .get_or_init(|| async move {
@@ -396,7 +431,7 @@ impl AppState {
 
     /// Lazily load the whisper transcriber.
     pub(crate) async fn ensure_transcriber(&self) -> Result<Arc<dyn Transcriber>, IpcError> {
-        let asr_path = self.model_path.clone();
+        let asr_path = self.model_path.read().unwrap().clone();
         let data_root = self.data_root.clone();
         self.transcriber
             .get_or_init(|| async move {
@@ -501,7 +536,11 @@ fn preferred_asr_model(root: &Path) -> &'static str {
     "models/asr/ggml-large-v3-turbo.bin"
 }
 
-fn resolve_asset_path(root: &Path, override_value: Option<String>, default_relative: &str) -> PathBuf {
+fn resolve_asset_path(
+    root: &Path,
+    override_value: Option<String>,
+    default_relative: &str,
+) -> PathBuf {
     if let Some(raw) = override_value.filter(|s| !s.trim().is_empty()) {
         let raw_path = PathBuf::from(&raw);
         if raw_path.is_absolute() {

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -367,10 +367,7 @@ pub async fn cancel_download(
 /// If the model is currently loaded in memory, it is unloaded first.
 #[tauri::command]
 #[specta::specta]
-pub async fn delete_model(
-    state: State<'_, AppState>,
-    model_id: String,
-) -> Result<(), IpcError> {
+pub async fn delete_model(state: State<'_, AppState>, model_id: String) -> Result<(), IpcError> {
     let rel_path = model_dest_path(&model_id)
         .ok_or_else(|| IpcError::not_found(format!("unknown model: {model_id}")))?;
     let dest = state.data_root.join(rel_path);
@@ -384,9 +381,15 @@ pub async fn delete_model(
     // Unload the model from memory if it's currently loaded.
     let kind = model_id.split('-').next().unwrap_or("");
     match kind {
-        "asr" => { state.transcriber.unload().await; }
-        "llm" => { state.llm.unload().await; }
-        "vad" => { state.vad.unload().await; }
+        "asr" => {
+            state.transcriber.unload().await;
+        }
+        "llm" => {
+            state.llm.unload().await;
+        }
+        "vad" => {
+            state.vad.unload().await;
+        }
         _ => {}
     }
 
@@ -395,4 +398,126 @@ pub async fn delete_model(
         .map_err(|e| IpcError::storage(format!("failed to delete model: {e}")))?;
 
     Ok(())
+}
+
+/// Set the active LLM model. Unloads the currently loaded model (if
+/// any) and switches the path so the next `ensure_llm()` call loads
+/// the selected model.
+///
+/// `model_id` must be an `"llm-*"` id from the catalog whose model
+/// file is already downloaded.
+#[tauri::command]
+#[specta::specta]
+pub async fn set_active_llm(state: State<'_, AppState>, model_id: String) -> Result<(), IpcError> {
+    let rel_path = model_dest_path(&model_id)
+        .ok_or_else(|| IpcError::not_found(format!("unknown model: {model_id}")))?;
+
+    if !model_id.starts_with("llm-") {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            format!("{model_id} is not an LLM model"),
+        ));
+    }
+
+    let dest = state.data_root.join(rel_path);
+    if !dest.exists() {
+        return Err(IpcError::not_found(format!(
+            "model not downloaded: {model_id}"
+        )));
+    }
+
+    // Unload the currently loaded LLM (if any).
+    state.llm.unload().await;
+
+    // SAFETY: We hold an exclusive reference via `State` in the Tauri
+    // runtime; this is the only writer. The `unsafe` block is required
+    // because `llm_model_path` is not behind an async mutex (to keep
+    // it cheap to read). The Tauri command pipeline guarantees single-
+    // writer semantics per command invocation.
+    //
+    // We use an interior-mutability pattern via a small helper below
+    // to update the path.
+    state.set_llm_model_path(dest);
+
+    tracing::info!(model_id = %model_id, "active LLM switched");
+    Ok(())
+}
+
+/// Return the model id of the currently configured LLM, or `null`
+/// when no LLM model file exists on disk.
+#[tauri::command]
+#[specta::specta]
+pub fn get_active_llm(state: State<'_, AppState>) -> Option<String> {
+    let path = state.active_llm_path();
+    if !path.exists() {
+        return None;
+    }
+    // Reverse-lookup the catalog id from the filename.
+    let catalog = model_catalog(&state.data_root);
+    for (info, _, _) in &catalog {
+        if info.kind == "llm" {
+            let rel = model_dest_path(&info.id).unwrap_or("");
+            if state.data_root.join(rel) == path {
+                return Some(info.id.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Set the active ASR (speech recognition) model. Unloads the currently
+/// loaded transcriber (if any) and switches the path so the next
+/// `ensure_transcriber()` call loads the selected model.
+///
+/// `model_id` must be an `"asr-*"` id from the catalog whose model
+/// file is already downloaded.
+#[tauri::command]
+#[specta::specta]
+pub async fn set_active_asr(state: State<'_, AppState>, model_id: String) -> Result<(), IpcError> {
+    let rel_path = model_dest_path(&model_id)
+        .ok_or_else(|| IpcError::not_found(format!("unknown model: {model_id}")))?;
+
+    if !model_id.starts_with("asr-") {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            format!("{model_id} is not an ASR model"),
+        ));
+    }
+
+    let dest = state.data_root.join(rel_path);
+    if !dest.exists() {
+        return Err(IpcError::not_found(format!(
+            "model not downloaded: {model_id}"
+        )));
+    }
+
+    // Unload the currently loaded transcriber (if any).
+    state.transcriber.unload().await;
+
+    state.set_asr_model_path(dest);
+
+    tracing::info!(model_id = %model_id, "active ASR switched");
+    Ok(())
+}
+
+/// Return the model id of the currently configured ASR model, or `null`
+/// when no ASR model file exists on disk.
+#[tauri::command]
+#[specta::specta]
+pub fn get_active_asr(state: State<'_, AppState>) -> Option<String> {
+    let path = state.active_asr_path();
+    if !path.exists() {
+        return None;
+    }
+    // Reverse-lookup the catalog id from the filename.
+    let catalog = model_catalog(&state.data_root);
+    for (info, _, _) in &catalog {
+        if info.kind == "asr" {
+            let rel = model_dest_path(&info.id).unwrap_or("");
+            if state.data_root.join(rel) == path {
+                return Some(info.id.clone());
+            }
+        }
+    }
+    None
 }

--- a/src-tauri/src/commands/templates.rs
+++ b/src-tauri/src/commands/templates.rs
@@ -1,0 +1,155 @@
+//! Custom template CRUD commands.
+//!
+//! User-defined summary templates are stored as a JSON array in
+//! `<data_root>/custom_templates.json`. The file is read/written
+//! atomically on each operation — the list is small (tens of items
+//! at most) so there's no need for a SQLite table.
+
+use tauri::State;
+
+use crate::ipc_error::{ErrorCode, IpcError};
+
+use echo_domain::{CustomTemplate, CustomTemplateId};
+
+use super::AppState;
+
+/// Path to the custom templates JSON file.
+fn templates_path(state: &AppState) -> std::path::PathBuf {
+    state.data_root.join("custom_templates.json")
+}
+
+/// Read all custom templates from disk.
+fn read_templates(state: &AppState) -> Result<Vec<CustomTemplate>, IpcError> {
+    read_templates_from(state)
+}
+
+/// Read all custom templates — public within the crate so other
+/// command modules (e.g. `llm::summarize_with_custom_template`)
+/// can look up a template by id.
+pub(crate) fn read_templates_from(state: &AppState) -> Result<Vec<CustomTemplate>, IpcError> {
+    let path = templates_path(state);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let data = std::fs::read_to_string(&path)
+        .map_err(|e| IpcError::storage(format!("read custom templates: {e}")))?;
+    serde_json::from_str(&data)
+        .map_err(|e| IpcError::storage(format!("parse custom templates: {e}")))
+}
+
+/// Write all custom templates to disk atomically.
+fn write_templates(state: &AppState, templates: &[CustomTemplate]) -> Result<(), IpcError> {
+    let path = templates_path(state);
+    let data = serde_json::to_string_pretty(templates)
+        .map_err(|e| IpcError::storage(format!("serialize custom templates: {e}")))?;
+    // Write to a temp file first, then rename for atomicity.
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, data.as_bytes())
+        .map_err(|e| IpcError::storage(format!("write custom templates: {e}")))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| IpcError::storage(format!("rename custom templates: {e}")))?;
+    Ok(())
+}
+
+/// List all user-defined custom templates.
+#[tauri::command]
+#[specta::specta]
+pub fn list_custom_templates(state: State<'_, AppState>) -> Result<Vec<CustomTemplate>, IpcError> {
+    read_templates(&state)
+}
+
+/// Create a new custom template.
+///
+/// The `name` and `prompt` fields are required and must be non-empty.
+/// Returns the newly created template with its generated id.
+#[tauri::command]
+#[specta::specta]
+pub fn create_custom_template(
+    state: State<'_, AppState>,
+    name: String,
+    prompt: String,
+) -> Result<CustomTemplate, IpcError> {
+    let name = name.trim().to_string();
+    let prompt = prompt.trim().to_string();
+    if name.is_empty() {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            "template name cannot be empty".to_string(),
+        ));
+    }
+    if prompt.is_empty() {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            "template prompt cannot be empty".to_string(),
+        ));
+    }
+
+    let template = CustomTemplate {
+        id: CustomTemplateId::new(),
+        name,
+        prompt,
+    };
+
+    let mut templates = read_templates(&state)?;
+    templates.push(template.clone());
+    write_templates(&state, &templates)?;
+
+    Ok(template)
+}
+
+/// Update an existing custom template's name and/or prompt.
+#[tauri::command]
+#[specta::specta]
+pub fn update_custom_template(
+    state: State<'_, AppState>,
+    id: CustomTemplateId,
+    name: String,
+    prompt: String,
+) -> Result<CustomTemplate, IpcError> {
+    let name = name.trim().to_string();
+    let prompt = prompt.trim().to_string();
+    if name.is_empty() {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            "template name cannot be empty".to_string(),
+        ));
+    }
+    if prompt.is_empty() {
+        return Err(IpcError::new(
+            ErrorCode::InvalidInput,
+            "template prompt cannot be empty".to_string(),
+        ));
+    }
+
+    let mut templates = read_templates(&state)?;
+    let tmpl = templates
+        .iter_mut()
+        .find(|t| t.id == id)
+        .ok_or_else(|| IpcError::not_found(format!("custom template {id} not found")))?;
+
+    tmpl.name = name;
+    tmpl.prompt = prompt;
+    let updated = tmpl.clone();
+    write_templates(&state, &templates)?;
+
+    Ok(updated)
+}
+
+/// Delete a custom template by id.
+#[tauri::command]
+#[specta::specta]
+pub fn delete_custom_template(
+    state: State<'_, AppState>,
+    id: CustomTemplateId,
+) -> Result<(), IpcError> {
+    let mut templates = read_templates(&state)?;
+    let before = templates.len();
+    templates.retain(|t| t.id != id);
+    if templates.len() == before {
+        return Err(IpcError::not_found(format!(
+            "custom template {id} not found"
+        )));
+    }
+    write_templates(&state, &templates)?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,6 +47,15 @@ pub fn run() {
             commands::models::unload_model,
             commands::models::cancel_download,
             commands::models::delete_model,
+            commands::models::set_active_llm,
+            commands::models::get_active_llm,
+            commands::models::set_active_asr,
+            commands::models::get_active_asr,
+            commands::templates::list_custom_templates,
+            commands::templates::create_custom_template,
+            commands::templates::update_custom_template,
+            commands::templates::delete_custom_template,
+            commands::llm::summarize_with_custom_template,
         ]);
 
     // In dev builds, export TypeScript bindings so the frontend can

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "EchoNote",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "identifier": "app.echonote.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/features/meetings/SummaryPanel.tsx
+++ b/src/features/meetings/SummaryPanel.tsx
@@ -9,16 +9,22 @@
  *   3. **Loaded**    a `Summary` exists; render the structured
  *                    sections, plus a "Regenerate" affordance.
  *
- * A template selector lets the user pick any of the six templates
- * before generating. The selector syncs with the loaded summary's
- * template on mount so "Regenerate" targets the right one.
+ * A template selector lets the user pick any of the six built-in
+ * templates or a user-defined custom template before generating. The
+ * selector syncs with the loaded summary's template on mount so
+ * "Regenerate" targets the right one.
  */
 
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { LogoAnimated } from "../../components/Logo";
 import { formatDate } from "../../lib/format";
 import type { Summary, TemplateId } from "../../types/summary";
 import { TEMPLATE_IDS, TEMPLATE_LABELS } from "../../types/summary";
-import type { UseMeetingSummary } from "../../hooks/useMeetingSummary";
+import type { UseMeetingSummary, SelectedTemplate } from "../../hooks/useMeetingSummary";
+import type { CustomTemplate } from "../../types/custom-template";
+import { listCustomTemplates } from "../../ipc/client";
+import { TemplateManager } from "../settings/TemplateManager";
 
 export function SummaryPanel({
   state,
@@ -26,6 +32,18 @@ export function SummaryPanel({
   state: UseMeetingSummary;
 }>) {
   const { summary, loading, generating, error, selectedTemplate, setSelectedTemplate } = state;
+  const { t } = useTranslation();
+  const [customTemplates, setCustomTemplates] = useState<CustomTemplate[]>([]);
+  const [showTemplateManager, setShowTemplateManager] = useState(false);
+
+  const refreshCustomTemplates = () => {
+    listCustomTemplates().then(setCustomTemplates).catch(() => {});
+  };
+
+  useEffect(() => {
+    refreshCustomTemplates();
+  }, []);
+
   return (
     <section
       aria-label="Summary"
@@ -38,7 +56,18 @@ export function SummaryPanel({
             value={selectedTemplate}
             onChange={setSelectedTemplate}
             disabled={loading || generating}
+            customTemplates={customTemplates}
           />
+          <button
+            type="button"
+            onClick={() => setShowTemplateManager(true)}
+            className="rounded-md p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+            title={t("templates.manage")}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+              <path fillRule="evenodd" d="M6.455 1.45A.5.5 0 0 1 6.952 1h2.096a.5.5 0 0 1 .497.45l.186 1.858a4.996 4.996 0 0 1 1.466.848l1.703-.769a.5.5 0 0 1 .63.207l1.048 1.814a.5.5 0 0 1-.133.656l-1.517 1.09a5.026 5.026 0 0 1 0 1.694l1.517 1.09a.5.5 0 0 1 .133.656l-1.048 1.814a.5.5 0 0 1-.63.207l-1.703-.769a4.996 4.996 0 0 1-1.466.848l-.186 1.858a.5.5 0 0 1-.497.45H6.952a.5.5 0 0 1-.497-.45l-.186-1.858a4.993 4.993 0 0 1-1.466-.848l-1.703.769a.5.5 0 0 1-.63-.207L1.422 12.4a.5.5 0 0 1 .133-.656l1.517-1.09a5.026 5.026 0 0 1 0-1.694l-1.517-1.09a.5.5 0 0 1-.133-.656l1.048-1.814a.5.5 0 0 1 .63-.207l1.703.769a4.993 4.993 0 0 1 1.466-.848l.186-1.858ZM8 10.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" clipRule="evenodd" />
+            </svg>
+          </button>
           <SummaryActions
             summary={summary}
             generating={generating}
@@ -49,6 +78,13 @@ export function SummaryPanel({
           />
         </div>
       </header>
+
+      {showTemplateManager && (
+        <TemplateManager
+          onClose={() => setShowTemplateManager(false)}
+          onChanged={refreshCustomTemplates}
+        />
+      )}
 
       {error && (
         <p className="text-xs text-amber-700 dark:text-amber-400">{error}</p>
@@ -78,15 +114,32 @@ function TemplateSelector({
   value,
   onChange,
   disabled,
+  customTemplates,
 }: Readonly<{
-  value: TemplateId;
-  onChange: (t: TemplateId) => void;
+  value: SelectedTemplate;
+  onChange: (t: SelectedTemplate) => void;
   disabled: boolean;
+  customTemplates: CustomTemplate[];
 }>) {
+  const selectValue =
+    value.kind === "builtin" ? value.id : `custom:${value.id}`;
+
+  const handleChange = (raw: string) => {
+    if (raw.startsWith("custom:")) {
+      const cid = raw.slice("custom:".length);
+      const ct = customTemplates.find((t) => t.id === cid);
+      if (ct) {
+        onChange({ kind: "custom", id: ct.id, name: ct.name });
+      }
+    } else {
+      onChange({ kind: "builtin", id: raw as TemplateId });
+    }
+  };
+
   return (
     <select
-      value={value}
-      onChange={(e) => onChange(e.target.value as TemplateId)}
+      value={selectValue}
+      onChange={(e) => handleChange(e.target.value)}
       disabled={disabled}
       className="rounded-md border border-zinc-200 bg-white px-1.5 py-1 text-xs disabled:opacity-60 dark:border-zinc-800 dark:bg-zinc-900"
     >
@@ -95,6 +148,15 @@ function TemplateSelector({
           {TEMPLATE_LABELS[id]}
         </option>
       ))}
+      {customTemplates.length > 0 && (
+        <optgroup label="Custom">
+          {customTemplates.map((ct) => (
+            <option key={ct.id} value={`custom:${ct.id}`}>
+              {ct.name}
+            </option>
+          ))}
+        </optgroup>
+      )}
     </select>
   );
 }
@@ -229,6 +291,18 @@ function renderTemplateBody(summary: Summary) {
       return (
         <div className="whitespace-pre-wrap text-zinc-800 dark:text-zinc-200">
           {summary.text || "[empty summary]"}
+        </div>
+      );
+
+    case "custom":
+      return (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400">
+            {summary.templateName}
+          </p>
+          <div className="whitespace-pre-wrap text-zinc-800 dark:text-zinc-200">
+            {summary.text || "[empty summary]"}
+          </div>
         </div>
       );
 

--- a/src/features/settings/ModelManager.tsx
+++ b/src/features/settings/ModelManager.tsx
@@ -24,10 +24,19 @@ export function ModelManager({
   state: UseModelManager;
   onClose: () => void;
 }>) {
-  const { models, loading, downloading, error } = state;
+  const { models, loading, downloading, error, activeLlm, activeAsr } = state;
   const { t } = useTranslation();
 
   const grouped = groupByKind(models);
+
+  const activeIds: Record<string, string | null> = {
+    llm: activeLlm,
+    asr: activeAsr,
+  };
+  const selectHandlers: Record<string, (id: string) => void> = {
+    llm: state.selectLlm,
+    asr: state.selectAsr,
+  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
@@ -59,9 +68,11 @@ export function ModelManager({
                 kind={kind}
                 models={items}
                 downloading={downloading}
+                activeId={activeIds[kind] ?? null}
                 onDownload={state.download}
                 onCancel={state.cancelDl}
                 onDelete={state.remove}
+                {...(selectHandlers[kind] ? { onSelect: selectHandlers[kind] } : {})}
               />
             ))}
           </div>
@@ -99,18 +110,23 @@ function ModelGroup({
   kind,
   models,
   downloading,
+  activeId,
   onDownload,
   onCancel,
   onDelete,
+  onSelect,
 }: Readonly<{
   kind: string;
   models: ModelInfo[];
   downloading: DownloadProgress | null;
+  activeId: string | null;
   onDownload: (id: string) => void;
   onCancel: (id: string) => void;
   onDelete: (id: string) => void;
+  onSelect?: (id: string) => void;
 }>) {
   const { t } = useTranslation();
+  const selectable = kind === "llm" || kind === "asr";
   return (
     <div className="flex flex-col gap-2">
       <h3 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
@@ -121,9 +137,12 @@ function ModelGroup({
           key={m.id}
           model={m}
           downloading={downloading}
+          isActive={selectable && m.id === activeId}
+          showUse={selectable}
           onDownload={onDownload}
           onCancel={onCancel}
           onDelete={onDelete}
+          {...(onSelect ? { onSelect } : {})}
         />
       ))}
     </div>
@@ -133,15 +152,21 @@ function ModelGroup({
 function ModelRow({
   model,
   downloading,
+  isActive,
+  showUse,
   onDownload,
   onCancel,
   onDelete,
+  onSelect,
 }: Readonly<{
   model: ModelInfo;
   downloading: DownloadProgress | null;
+  isActive: boolean;
+  showUse: boolean;
   onDownload: (id: string) => void;
   onCancel: (id: string) => void;
   onDelete: (id: string) => void;
+  onSelect?: (id: string) => void;
 }>) {
   const { t } = useTranslation();
   const isDownloading = downloading?.modelId === model.id;
@@ -152,8 +177,12 @@ function ModelRow({
       : 0;
 
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-zinc-100 bg-zinc-50/50 px-3 py-2.5 dark:border-zinc-800/60 dark:bg-zinc-900/30">
-      <StatusDot present={model.present} />
+    <div className={`flex items-center gap-3 rounded-lg border px-3 py-2.5 ${
+      isActive
+        ? "border-blue-200 bg-blue-50/50 dark:border-blue-800/60 dark:bg-blue-950/20"
+        : "border-zinc-100 bg-zinc-50/50 dark:border-zinc-800/60 dark:bg-zinc-900/30"
+    }`}>
+      <StatusDot present={model.present} active={isActive} />
 
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">
@@ -188,6 +217,20 @@ function ModelRow({
       )}
       {!isDownloading && model.present && (
         <div className="flex shrink-0 items-center gap-1.5">
+          {showUse && !isActive && onSelect && (
+            <button
+              type="button"
+              onClick={() => onSelect(model.id)}
+              className="rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-[10px] font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
+            >
+              {t("models.use")}
+            </button>
+          )}
+          {isActive && (
+            <span className="rounded-md bg-blue-100 px-2 py-1 text-[10px] font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300">
+              {t("models.active")}
+            </span>
+          )}
           <span className="rounded-md bg-emerald-50 px-2 py-1 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
             {t("models.installed")}
           </span>
@@ -217,14 +260,9 @@ function ModelRow({
   );
 }
 
-function StatusDot({ present }: Readonly<{ present: boolean }>) {
-  return (
-    <span
-      className={`h-2 w-2 shrink-0 rounded-full ${
-        present
-          ? "bg-emerald-500"
-          : "bg-zinc-300 dark:bg-zinc-600"
-      }`}
-    />
-  );
+function StatusDot({ present, active }: Readonly<{ present: boolean; active: boolean }>) {
+  let color = "bg-zinc-300 dark:bg-zinc-600";
+  if (active) color = "bg-blue-500";
+  else if (present) color = "bg-emerald-500";
+  return <span className={`h-2 w-2 shrink-0 rounded-full ${color}`} />;
 }

--- a/src/features/settings/TemplateManager.tsx
+++ b/src/features/settings/TemplateManager.tsx
@@ -1,0 +1,236 @@
+/**
+ * `TemplateManager` — modal panel for CRUD on custom summary templates.
+ *
+ * Users can create, edit, and delete their own prompt templates that
+ * appear in the SummaryPanel's template selector alongside the built-in ones.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { CustomTemplate, CustomTemplateId } from "../../types/custom-template";
+import {
+  listCustomTemplates,
+  createCustomTemplate,
+  updateCustomTemplate,
+  deleteCustomTemplate,
+} from "../../ipc/client";
+
+type FormState = {
+  name: string;
+  prompt: string;
+};
+
+const EMPTY_FORM: FormState = { name: "", prompt: "" };
+
+export function TemplateManager({
+  onClose,
+  onChanged,
+}: Readonly<{
+  onClose: () => void;
+  onChanged?: () => void;
+}>) {
+  const { t } = useTranslation();
+  const [templates, setTemplates] = useState<CustomTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Editing state: null = creating new, string = editing existing id
+  const [editingId, setEditingId] = useState<CustomTemplateId | null>(null);
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [showForm, setShowForm] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(() => {
+    setLoading(true);
+    listCustomTemplates()
+      .then(setTemplates)
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleNew = useCallback(() => {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowForm(true);
+    setError(null);
+  }, []);
+
+  const handleEdit = useCallback((tpl: CustomTemplate) => {
+    setEditingId(tpl.id);
+    setForm({ name: tpl.name, prompt: tpl.prompt });
+    setShowForm(true);
+    setError(null);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    setShowForm(false);
+    setForm(EMPTY_FORM);
+    setEditingId(null);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const trimmedName = form.name.trim();
+    const trimmedPrompt = form.prompt.trim();
+    if (!trimmedName || !trimmedPrompt) return;
+
+    setSaving(true);
+    setError(null);
+    try {
+      if (editingId) {
+        await updateCustomTemplate(editingId, trimmedName, trimmedPrompt);
+      } else {
+        await createCustomTemplate(trimmedName, trimmedPrompt);
+      }
+      setShowForm(false);
+      setForm(EMPTY_FORM);
+      setEditingId(null);
+      refresh();
+      onChanged?.();
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [form, editingId, refresh, onChanged]);
+
+  const handleDelete = useCallback(
+    async (id: CustomTemplateId) => {
+      setError(null);
+      try {
+        await deleteCustomTemplate(id);
+        refresh();
+        onChanged?.();
+      } catch (err) {
+        setError(String(err));
+      }
+    },
+    [refresh, onChanged],
+  );
+
+  const saveKey = editingId ? "templates.save" : "templates.create";
+  const saveLabel = saving ? t("templates.saving") : t(saveKey);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="flex max-h-[80vh] w-full max-w-lg flex-col gap-3 overflow-hidden rounded-xl border border-zinc-200 bg-white p-5 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
+        <header className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">{t("templates.title")}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-xs text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-900"
+          >
+            {t("templates.close")}
+          </button>
+        </header>
+
+        {error && (
+          <p className="rounded-md bg-red-50 px-3 py-2 text-xs text-red-700 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <p className="py-6 text-center text-sm text-zinc-500">{t("templates.loading")}</p>
+        ) : (
+          <div className="flex min-h-0 flex-col gap-3 overflow-y-auto">
+            {templates.length === 0 && !showForm && (
+              <p className="py-4 text-center text-sm text-zinc-500">{t("templates.empty")}</p>
+            )}
+
+            {templates.map((tpl) => (
+              <div
+                key={tpl.id}
+                className="flex items-start gap-3 rounded-lg border border-zinc-100 bg-zinc-50/50 px-3 py-2.5 dark:border-zinc-800/60 dark:bg-zinc-900/30"
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                    {tpl.name}
+                  </span>
+                  <span className="line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">
+                    {tpl.prompt}
+                  </span>
+                </div>
+                <div className="flex shrink-0 items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => handleEdit(tpl)}
+                    className="rounded-md p-1 text-zinc-400 hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+                    title={t("templates.edit")}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                      <path d="M13.488 2.513a1.75 1.75 0 0 0-2.475 0L3.84 9.686a2.25 2.25 0 0 0-.602 1.07l-.56 2.243a.75.75 0 0 0 .912.912l2.243-.56a2.25 2.25 0 0 0 1.07-.602l7.174-7.174a1.75 1.75 0 0 0 0-2.474l-.588-.588ZM11.72 3.22a.25.25 0 0 1 .354 0l.588.588a.25.25 0 0 1 0 .354L11.95 4.874 10.807 3.93l.913-.71ZM10.1 4.636l1.143.944-5.498 5.498a.75.75 0 0 1-.357.2l-1.396.35.349-1.397a.75.75 0 0 1 .2-.357l5.56-5.238Z" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(tpl.id)}
+                    className="rounded-md p-1 text-zinc-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+                    title={t("templates.delete")}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3.5 w-3.5">
+                      <path fillRule="evenodd" d="M5 3.25V4H2.75a.75.75 0 0 0 0 1.5h.3l.815 8.15A1.5 1.5 0 0 0 5.357 15h5.285a1.5 1.5 0 0 0 1.493-1.35l.815-8.15h.3a.75.75 0 0 0 0-1.5H11v-.75A2.25 2.25 0 0 0 8.75 1h-1.5A2.25 2.25 0 0 0 5 3.25Zm2.25-.75a.75.75 0 0 0-.75.75V4h3v-.75a.75.75 0 0 0-.75-.75h-1.5ZM6.05 6a.75.75 0 0 1 .787.713l.275 5.5a.75.75 0 0 1-1.498.075l-.275-5.5A.75.75 0 0 1 6.05 6Zm3.9 0a.75.75 0 0 1 .712.787l-.275 5.5a.75.75 0 0 1-1.498-.075l.275-5.5A.75.75 0 0 1 9.95 6Z" clipRule="evenodd" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+            ))}
+
+            {showForm && (
+              <div className="flex flex-col gap-2 rounded-lg border border-blue-200 bg-blue-50/30 p-3 dark:border-blue-800/60 dark:bg-blue-950/20">
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+                  placeholder={t("templates.namePlaceholder")}
+                  className="w-full rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-800 placeholder:text-zinc-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:placeholder:text-zinc-500"
+                  maxLength={100}
+                />
+                <textarea
+                  value={form.prompt}
+                  onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}
+                  placeholder={t("templates.promptPlaceholder")}
+                  rows={5}
+                  className="w-full resize-y rounded-md border border-zinc-200 bg-white px-2.5 py-1.5 text-sm text-zinc-800 placeholder:text-zinc-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:placeholder:text-zinc-500"
+                  maxLength={4000}
+                />
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCancel}
+                    className="rounded-md px-3 py-1.5 text-xs font-medium text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800"
+                  >
+                    {t("templates.cancel")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSave}
+                    disabled={saving || !form.name.trim() || !form.prompt.trim()}
+                    className="rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
+                  >
+                    {saveLabel}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {!showForm && !loading && (
+          <button
+            type="button"
+            onClick={handleNew}
+            className="mt-1 self-start rounded-md border border-blue-200 bg-blue-50 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300 dark:hover:bg-blue-900/60"
+          >
+            {t("templates.new")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useMeetingSummary.ts
+++ b/src/hooks/useMeetingSummary.ts
@@ -25,18 +25,24 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getSummary, summarizeMeeting } from "../ipc/client";
+import { getSummary, summarizeMeeting, summarizeWithCustomTemplate } from "../ipc/client";
 import { useIpcAction } from "../ipc/useIpcAction";
 import type { MeetingId } from "../types/meeting";
 import type { Summary, TemplateId } from "../types/summary";
+import type { CustomTemplateId } from "../types/custom-template";
+
+/** The template selector can pick a built-in or a custom template. */
+export type SelectedTemplate =
+  | { kind: "builtin"; id: TemplateId }
+  | { kind: "custom"; id: CustomTemplateId; name: string };
 
 export type UseMeetingSummary = {
   summary: Summary | null;
   loading: boolean;
   generating: boolean;
   error: string | null;
-  selectedTemplate: TemplateId;
-  setSelectedTemplate: (t: TemplateId) => void;
+  selectedTemplate: SelectedTemplate;
+  setSelectedTemplate: (t: SelectedTemplate) => void;
   generate: () => Promise<Summary | undefined>;
 };
 
@@ -45,7 +51,10 @@ export function useMeetingSummary(meetingId: MeetingId | null): UseMeetingSummar
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateId>("general");
+  const [selectedTemplate, setSelectedTemplate] = useState<SelectedTemplate>({
+    kind: "builtin",
+    id: "general",
+  });
 
   const requestedRef = useRef<MeetingId | null>(null);
 
@@ -69,7 +78,15 @@ export function useMeetingSummary(meetingId: MeetingId | null): UseMeetingSummar
         // Sync the selector to the loaded template so "Regenerate"
         // targets the right one.
         if (fetched) {
-          setSelectedTemplate(fetched.template as TemplateId);
+          if (fetched.template === "custom") {
+            setSelectedTemplate({
+              kind: "custom",
+              id: "", // id unknown from stored summary
+              name: (fetched as { templateName?: string }).templateName ?? "Custom",
+            });
+          } else {
+            setSelectedTemplate({ kind: "builtin", id: fetched.template as TemplateId });
+          }
         }
       } catch (err) {
         if (cancelled || requestedRef.current !== meetingId) return;
@@ -86,16 +103,26 @@ export function useMeetingSummary(meetingId: MeetingId | null): UseMeetingSummar
     };
   }, [meetingId]);
 
-  const generateCall = useIpcAction(
+  const generateBuiltinCall = useIpcAction(
     "Couldn't generate summary.",
     summarizeMeeting,
+  );
+
+  const generateCustomCall = useIpcAction(
+    "Couldn't generate summary.",
+    summarizeWithCustomTemplate,
   );
 
   const generate = useCallback(async (): Promise<Summary | undefined> => {
     if (!meetingId) return undefined;
     setGenerating(true);
     try {
-      const fresh = await generateCall(meetingId, selectedTemplate);
+      let fresh: Summary | undefined;
+      if (selectedTemplate.kind === "custom") {
+        fresh = await generateCustomCall(meetingId, selectedTemplate.id);
+      } else {
+        fresh = await generateBuiltinCall(meetingId, selectedTemplate.id);
+      }
       if (fresh && requestedRef.current === meetingId) {
         setSummary(fresh);
       }
@@ -103,7 +130,7 @@ export function useMeetingSummary(meetingId: MeetingId | null): UseMeetingSummar
     } finally {
       setGenerating(false);
     }
-  }, [meetingId, selectedTemplate, generateCall]);
+  }, [meetingId, selectedTemplate, generateBuiltinCall, generateCustomCall]);
 
   return {
     summary,

--- a/src/hooks/useModelManager.ts
+++ b/src/hooks/useModelManager.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { cancelDownload, deleteModel, downloadModel, getModelStatus } from "../ipc/client";
+import { cancelDownload, deleteModel, downloadModel, getModelStatus, setActiveLlm, getActiveLlm, setActiveAsr, getActiveAsr } from "../ipc/client";
 import { isIpcError } from "../types/ipc-error";
 import type { DownloadEvent, ModelInfo } from "../types/models";
 
@@ -14,10 +14,14 @@ export type UseModelManager = {
   loading: boolean;
   downloading: DownloadProgress | null;
   error: string | null;
+  activeLlm: string | null;
+  activeAsr: string | null;
   refresh: () => void;
   download: (modelId: string) => void;
   cancelDl: (modelId: string) => void;
   remove: (modelId: string) => void;
+  selectLlm: (modelId: string) => void;
+  selectAsr: (modelId: string) => void;
 };
 
 export function useModelManager(): UseModelManager {
@@ -25,14 +29,20 @@ export function useModelManager(): UseModelManager {
   const [loading, setLoading] = useState(true);
   const [downloading, setDownloading] = useState<DownloadProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [activeLlm, setActiveLlmState] = useState<string | null>(null);
+  const [activeAsr, setActiveAsrState] = useState<string | null>(null);
   const mountedRef = useRef(true);
 
   const fetchStatus = useCallback(() => {
     setLoading(true);
     setError(null);
-    getModelStatus()
-      .then((result) => {
-        if (mountedRef.current) setModels(result);
+    Promise.all([getModelStatus(), getActiveLlm(), getActiveAsr()])
+      .then(([result, activeLlmId, activeAsrId]) => {
+        if (mountedRef.current) {
+          setModels(result);
+          setActiveLlmState(activeLlmId);
+          setActiveAsrState(activeAsrId);
+        }
       })
       .catch((err) => {
         if (mountedRef.current) {
@@ -123,5 +133,45 @@ export function useModelManager(): UseModelManager {
     [fetchStatus],
   );
 
-  return { models, loading, downloading, error, refresh: fetchStatus, download, cancelDl, remove };
+  const selectLlm = useCallback(
+    (modelId: string) => {
+      setError(null);
+      setActiveLlm(modelId)
+        .then(() => {
+          if (mountedRef.current) setActiveLlmState(modelId);
+        })
+        .catch((err) => {
+          if (mountedRef.current) {
+            let msg: string;
+            if (isIpcError(err)) msg = err.message;
+            else if (err instanceof Error) msg = err.message;
+            else msg = String(err);
+            setError(msg);
+          }
+        });
+    },
+    [],
+  );
+
+  const selectAsr = useCallback(
+    (modelId: string) => {
+      setError(null);
+      setActiveAsr(modelId)
+        .then(() => {
+          if (mountedRef.current) setActiveAsrState(modelId);
+        })
+        .catch((err) => {
+          if (mountedRef.current) {
+            let msg: string;
+            if (isIpcError(err)) msg = err.message;
+            else if (err instanceof Error) msg = err.message;
+            else msg = String(err);
+            setError(msg);
+          }
+        });
+    },
+    [],
+  );
+
+  return { models, loading, downloading, error, activeLlm, activeAsr, refresh: fetchStatus, download, cancelDl, remove, selectLlm, selectAsr };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -124,7 +124,25 @@
     "downloading": "Downloading…",
     "download": "Download ({{size}})",
     "cancel": "Cancel",
-    "delete": "Delete model"
+    "delete": "Delete model",
+    "use": "Use",
+    "active": "Active"
+  },
+  "templates": {
+    "title": "Custom Templates",
+    "close": "Close",
+    "loading": "Loading templates…",
+    "empty": "No custom templates yet. Create one to use your own prompts.",
+    "new": "+ New template",
+    "edit": "Edit template",
+    "delete": "Delete template",
+    "cancel": "Cancel",
+    "save": "Save",
+    "create": "Create",
+    "saving": "Saving…",
+    "namePlaceholder": "Template name…",
+    "promptPlaceholder": "Write your summary prompt here… The meeting transcript will be appended automatically.",
+    "manage": "Manage templates"
   },
   "errors": {
     "renderCrash": "fatal — render error",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -124,7 +124,25 @@
     "downloading": "Descargando…",
     "download": "Descargar ({{size}})",
     "cancel": "Cancelar",
-    "delete": "Eliminar modelo"
+    "delete": "Eliminar modelo",
+    "use": "Usar",
+    "active": "Activo"
+  },
+  "templates": {
+    "title": "Plantillas personalizadas",
+    "close": "Cerrar",
+    "loading": "Cargando plantillas…",
+    "empty": "Sin plantillas personalizadas aún. Crea una para usar tus propios prompts.",
+    "new": "+ Nueva plantilla",
+    "edit": "Editar plantilla",
+    "delete": "Eliminar plantilla",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "create": "Crear",
+    "saving": "Guardando…",
+    "namePlaceholder": "Nombre de la plantilla…",
+    "promptPlaceholder": "Escribe tu prompt de resumen aquí… La transcripción de la reunión se agregará automáticamente.",
+    "manage": "Gestionar plantillas"
   },
   "errors": {
     "renderCrash": "fatal — error de renderizado",

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -92,7 +92,7 @@ async renameSpeaker(meetingId: MeetingId, speakerId: SpeakerId, label: string | 
  * ordered by FTS5 BM25 rank (best match first). Empty / whitespace-
  * only queries return an empty vec — the frontend wires this to
  * `onChange` debounced, so the initial empty state never errors.
- *
+ * 
  * `limit` defaults to 20 (a comfortable sidebar page); `0` means no
  * cap. The query is sanitised inside the storage layer, so the
  * frontend can pass raw user input without worrying about FTS5
@@ -108,7 +108,7 @@ async searchMeetings(query: string, limit: number | null) : Promise<Result<Meeti
 },
 /**
  * Generate (or regenerate) the local-LLM summary for a meeting.
- *
+ * 
  * `template` selects the prompt template: `"general"` (default),
  * `"oneOnOne"`, `"sprintReview"`, `"interview"`, `"salesCall"`, or
  * `"lecture"`. Passing `null` or omitting the field defaults to
@@ -138,14 +138,14 @@ async getSummary(meetingId: MeetingId) : Promise<Result<Summary | null, IpcError
 },
 /**
  * Run one chat turn against a meeting's transcript.
- *
+ * 
  * Each invocation streams the assistant's reply token-by-token through
  * `on_event` and resolves the IPC promise once the stream terminates
  * (with [`AskAboutMeetingEvent::Finished`] on success or
  * [`AskAboutMeetingEvent::Failed`] on a mid-decode error).
- *
+ * 
  * ## Lifecycle
- *
+ * 
  * 1. Pre-stream errors (meeting not found, empty question, model
  * not loaded) come back as `Err(String)` so the UI can show a
  * toast without parsing event variants.
@@ -163,9 +163,9 @@ async getSummary(meetingId: MeetingId) : Promise<Result<Summary | null, IpcError
  * is needed — symmetric with `start_streaming` was deliberately
  * not chosen because chat is bounded (one Q&A turn ≤ ~10s on
  * Qwen 14B, vs streaming sessions that can run hours).
- *
+ * 
  * ## Why we don't spawn a background task
- *
+ * 
  * Unlike `start_streaming`, which returns a session id and runs
  * indefinitely until `stop_streaming`, a chat turn is a single
  * bounded interaction. Draining the stream inline keeps the IPC
@@ -183,11 +183,11 @@ async askAboutMeeting(meetingId: MeetingId, history: ChatMessage[] | null, quest
 },
 /**
  * Export a meeting (with optional summary) to a file at `dest_path`.
- *
+ * 
  * The frontend is responsible for showing the save-file dialog (via
  * `@tauri-apps/plugin-dialog`) and passing the chosen path here. This
  * command generates the formatted content and writes it atomically.
- *
+ * 
  * **Security:** `dest_path` is validated to be inside the user's home
  * directory and must not contain path-traversal components (`..`).
  */
@@ -207,7 +207,7 @@ async getModelStatus() : Promise<ModelInfo[]> {
 },
 /**
  * Download a model by id, streaming progress events to the frontend.
- *
+ * 
  * When the catalog entry includes a SHA-256 digest the downloaded file
  * is verified before being promoted from `*.part` to its final path.
  * Concurrent downloads of the same model are rejected.
@@ -232,6 +232,141 @@ async unloadModel(kind: string) : Promise<Result<boolean, IpcError>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Cancel an in-flight model download.
+ * 
+ * Sets the cancel flag for the download loop, which will clean up the
+ * `.part` file and send a `Cancelled` event.
+ */
+async cancelDownload(modelId: string) : Promise<Result<boolean, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_download", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Delete a downloaded model from disk.
+ * 
+ * If the model is currently loaded in memory, it is unloaded first.
+ */
+async deleteModel(modelId: string) : Promise<Result<null, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_model", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Set the active LLM model. Unloads the currently loaded model (if
+ * any) and switches the path so the next `ensure_llm()` call loads
+ * the selected model.
+ * 
+ * `model_id` must be an `"llm-*"` id from the catalog whose model
+ * file is already downloaded.
+ */
+async setActiveLlm(modelId: string) : Promise<Result<null, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_active_llm", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Return the model id of the currently configured LLM, or `null`
+ * when no LLM model file exists on disk.
+ */
+async getActiveLlm() : Promise<string | null> {
+    return await TAURI_INVOKE("get_active_llm");
+},
+/**
+ * Set the active ASR (speech recognition) model. Unloads the currently
+ * loaded transcriber (if any) and switches the path so the next
+ * `ensure_transcriber()` call loads the selected model.
+ * 
+ * `model_id` must be an `"asr-*"` id from the catalog whose model
+ * file is already downloaded.
+ */
+async setActiveAsr(modelId: string) : Promise<Result<null, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_active_asr", { modelId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Return the model id of the currently configured ASR model, or `null`
+ * when no ASR model file exists on disk.
+ */
+async getActiveAsr() : Promise<string | null> {
+    return await TAURI_INVOKE("get_active_asr");
+},
+/**
+ * List all user-defined custom templates.
+ */
+async listCustomTemplates() : Promise<Result<CustomTemplate[], IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("list_custom_templates") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Create a new custom template.
+ * 
+ * The `name` and `prompt` fields are required and must be non-empty.
+ * Returns the newly created template with its generated id.
+ */
+async createCustomTemplate(name: string, prompt: string) : Promise<Result<CustomTemplate, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_custom_template", { name, prompt }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Update an existing custom template's name and/or prompt.
+ */
+async updateCustomTemplate(id: CustomTemplateId, name: string, prompt: string) : Promise<Result<CustomTemplate, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_custom_template", { id, name, prompt }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Delete a custom template by id.
+ */
+async deleteCustomTemplate(id: CustomTemplateId) : Promise<Result<null, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("delete_custom_template", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Generate a summary using a user-defined custom template.
+ * 
+ * Loads the custom template by `template_id`, then runs the LLM with
+ * the user's prompt. The result is stored as
+ * [`echo_domain::SummaryContent::Custom`].
+ */
+async summarizeWithCustomTemplate(meetingId: MeetingId, templateId: CustomTemplateId) : Promise<Result<Summary, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("summarize_with_custom_template", { meetingId, templateId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -247,22 +382,22 @@ async unloadModel(kind: string) : Promise<Result<boolean, IpcError>> {
 
 /**
  * One actionable item extracted by the summarizer.
- *
+ * 
  * `owner` and `due` are best-effort; the LLM may leave either as
  * `None` when the transcript doesn't pin them down. The UI renders
  * them with sensible placeholders ("unassigned", "no due date") so
  * the summary remains useful even when partial.
  */
-export type ActionItem = {
+export type ActionItem = { 
 /**
  * What needs to be done. Required — an action item without a
  * task is meaningless.
  */
-task: string;
+task: string; 
 /**
  * Who is on the hook. `None` when the transcript doesn't say.
  */
-owner?: string | null;
+owner?: string | null; 
 /**
  * Free-form deadline as the LLM extracted it ("Friday", "next
  * sprint", "2026-05-01"). Kept as a string on purpose — parsing
@@ -274,9 +409,9 @@ due?: string | null }
  * Events the use case streams back to the caller. The discriminator
  * is on `kind` (camelCase for the IPC wire format) so the React layer
  * can `switch (event.kind)` directly.
- *
+ * 
  * Variant order:
- *
+ * 
  * 1. Exactly one [`Started`](Self::Started) at the top of the
  * stream, carrying the model id for provenance.
  * 2. Zero or more [`Token`](Self::Token) deltas — one per logical
@@ -286,24 +421,24 @@ due?: string | null }
  * [`Failed`](Self::Failed) if the adapter raised an error
  * mid-stream.
  */
-export type AskAboutMeetingEvent =
+export type AskAboutMeetingEvent = 
 /**
  * Stream is open; the model is about to start emitting tokens.
  * Carries the model id so the UI can show "powered by …" and so
  * chat-history persistence can stamp the right provenance.
  */
-{ kind: "started"; model: string } |
+{ kind: "started"; model: string } | 
 /**
  * One incremental piece of the model's reply. Forwarded verbatim
  * from [`echo_domain::ChatToken::delta`].
  */
-{ kind: "token"; delta: string } |
+{ kind: "token"; delta: string } | 
 /**
  * Stream completed normally. Carries the full assembled reply and
  * the citations parsed from it (deduplicated, validated against
  * the meeting's real segment ids).
  */
-{ kind: "finished"; text: string; citations: SegmentId[]; hadCitations: boolean } |
+{ kind: "finished"; text: string; citations: SegmentId[]; hadCitations: boolean } | 
 /**
  * The adapter raised an error after the stream had already
  * started. The IPC layer SHOULD treat this as a final event and
@@ -312,34 +447,34 @@ export type AskAboutMeetingEvent =
 { kind: "failed"; error: string }
 /**
  * Sample-rate / channel configuration of a stream.
- *
+ * 
  * Wire format uses `camelCase` so the JSON that crosses the Tauri /
  * CLI boundary matches the TypeScript `AudioFormat` (`sampleRateHz`,
  * `channels`). SQLite persistence uses dedicated columns and does
  * not go through serde, so this rename is purely an IPC concern.
  */
-export type AudioFormat = {
+export type AudioFormat = { 
 /**
  * Sampling frequency in hertz.
  */
-sampleRateHz: number;
+sampleRateHz: number; 
 /**
  * Number of interleaved channels (1 = mono, 2 = stereo, ...).
  */
 channels: number }
 /**
  * A single message inside a [`ChatRequest`].
- *
+ * 
  * `content` is plain UTF-8 text — adapters that need a different chat
  * template format (Qwen's `<|im_start|>system\n…<|im_end|>`, Llama's
  * `[INST] … [/INST]`, …) wrap each `ChatMessage` accordingly. The
  * domain layer stays template-agnostic.
  */
-export type ChatMessage = {
+export type ChatMessage = { 
 /**
  * Who authored this message.
  */
-role: ChatRole;
+role: ChatRole; 
 /**
  * Plain-text content. Empty strings are tolerated (the use case
  * occasionally sends empty assistant messages to "prime" the
@@ -348,23 +483,23 @@ role: ChatRole;
 content: string }
 /**
  * Author of a single message in a chat exchange.
- *
+ * 
  * The three roles mirror the OpenAI / llama.cpp chat-template
  * vocabulary exactly so the adapter can fold them into `<|im_start|>`,
  * `<s>[INST]` or any other model-specific framing without translation
  * tables.
  */
-export type ChatRole =
+export type ChatRole = 
 /**
  * Top-of-conversation instructions — typically the transcript
  * excerpt and the "you are a helpful assistant…" preamble.
  * At most one per request, conventionally the first message.
  */
-"system" |
+"system" | 
 /**
  * A turn authored by the human user.
  */
-"user" |
+"user" | 
 /**
  * A turn authored by the model in a previous round of the same
  * conversation. Re-fed verbatim so the model can stay coherent
@@ -372,14 +507,37 @@ export type ChatRole =
  */
 "assistant"
 /**
- * A term/definition pair extracted from a lecture or class
-
+ * A user-created summary prompt template.
  */
-export type Definition = {
+export type CustomTemplate = { 
+/**
+ * Stable identifier.
+ */
+id: CustomTemplateId; 
+/**
+ * Short display name shown in the template selector (e.g.
+ * "Product Standup", "Board Meeting").
+ */
+name: string; 
+/**
+ * The system-prompt text sent to the LLM. Should describe the
+ * role, desired output format, and any constraints.
+ * Example: "You are a product standup summarizer. Output a JSON
+ * object with keys: blockers, updates, askForHelp."
+ */
+prompt: string }
+/**
+ * Strongly-typed identifier for a [`CustomTemplate`].
+ */
+export type CustomTemplateId = string
+/**
+ * A term/definition pair extracted from a lecture or class
+ */
+export type Definition = { 
 /**
  * The term being defined.
  */
-term: string;
+term: string; 
 /**
  * The definition provided.
  */
@@ -387,71 +545,75 @@ definition: string }
 /**
  * Progress events streamed to the frontend during a download.
  */
-export type DownloadEvent =
+export type DownloadEvent = 
 /**
  * Periodic progress update.
  */
-{ kind: "progress"; downloaded: number; total: number } |
+{ kind: "progress"; downloaded: number; total: number } | 
 /**
  * Download finished successfully.
  */
-{ kind: "finished" } |
+{ kind: "finished" } | 
 /**
  * Download failed.
  */
-{ kind: "failed"; error: string }
+{ kind: "failed"; error: string } | 
+/**
+ * Download was cancelled by the user.
+ */
+{ kind: "cancelled" }
 /**
  * Machine-readable error codes the frontend can match on.
- *
+ * 
  * Kept intentionally coarse — add variants when the frontend needs
  * to distinguish a new failure mode, not for every conceivable
  * backend error.
  */
-export type ErrorCode =
+export type ErrorCode = 
 /**
  * A required record (meeting, speaker, segment, …) was not found.
  */
-"notFound" |
+"notFound" | 
 /**
  * Persistent storage failed (SQLite I/O, migration, …).
  */
-"storage" |
+"storage" | 
 /**
  * The local LLM could not load or inference failed.
  */
-"llm" |
+"llm" | 
 /**
  * The ASR engine could not load or transcription failed.
  */
-"asr" |
+"asr" | 
 /**
  * Input validation failed (empty question, bad template, …).
  */
-"invalidInput" |
+"invalidInput" | 
 /**
  * A streaming session conflict (poisoned map, duplicate id, …).
  */
-"sessionConflict" |
+"sessionConflict" | 
 /**
  * A required model is not downloaded yet.
  */
-"modelNotReady" |
+"modelNotReady" | 
 /**
  * Audio capture or device error.
  */
-"audio" |
+"audio" | 
 /**
  * Voice activity detection failed.
  */
-"vad" |
+"vad" | 
 /**
  * Speaker diarization failed.
  */
-"diarization" |
+"diarization" | 
 /**
  * An HTTP / network operation failed (model download, …).
  */
-"network" |
+"network" | 
 /**
  * Catch-all for unexpected / unclassified errors.
  */
@@ -463,19 +625,19 @@ export type ExportFormat = "markdown" | "txt"
 /**
  * Result returned by [`health_check`]. Mirrors `HealthStatus` on the TS side.
  */
-export type HealthStatus = {
+export type HealthStatus = { 
 /**
  * RFC 3339 timestamp of the probe.
  */
-timestamp: string;
+timestamp: string; 
 /**
  * Backend semver, from Cargo at compile time.
  */
-version: string;
+version: string; 
 /**
  * Target triple the backend was compiled for.
  */
-target: string;
+target: string; 
 /**
  * Short git hash, `unknown` when `.git` is missing at build time.
  */
@@ -484,15 +646,15 @@ commit: string }
  * A notable quote attributed to a speaker, used by the Interview
  * template.
  */
-export type InterviewQuote = {
+export type InterviewQuote = { 
 /**
  * Who said it.
  */
-speaker: string;
+speaker: string; 
 /**
  * Verbatim or near-verbatim quote.
  */
-quote: string;
+quote: string; 
 /**
  * Situational context around the quote.
  */
@@ -502,18 +664,18 @@ context?: string | null }
  * so the frontend stays stylistically consistent (the domain enum
  * uses snake_case for storage / CLI compatibility).
  */
-export type IpcAudioSource =
+export type IpcAudioSource = 
 /**
  * Default microphone via cpal.
  */
-"microphone" |
+"microphone" | 
 /**
  * System audio loopback (macOS 13+ via ScreenCaptureKit).
  */
 "systemOutput"
 /**
  * Structured error returned by every Tauri command.
- *
+ * 
  * Serializes to `{ "code": "notFound", "message": "…", "retriable": false }`
  * on the IPC wire, which the frontend's `useIpcAction` hook can
  * destructure for precise UX.
@@ -523,51 +685,51 @@ export type IpcError = { code: ErrorCode; message: string; retriable: boolean }
  * Full meeting aggregate. Returned by point lookups and includes the
  * segment list and any diarized speakers.
  */
-export type Meeting =
+export type Meeting = 
 /**
  * Summary projection.
  */
-({
+({ 
 /**
  * Stable identifier.
  */
-id: MeetingId;
+id: MeetingId; 
 /**
  * Human-readable title. Defaults to `"Meeting <date>"` when the
  * caller does not supply one.
  */
-title: string;
+title: string; 
 /**
  * RFC 3339 instant the recording started.
  */
-startedAt: string;
+startedAt: string; 
 /**
  * RFC 3339 instant the recording stopped. `None` while the
  * session is still running.
  */
-endedAt: string | null;
+endedAt: string | null; 
 /**
  * Total audio captured, in milliseconds.
  */
-durationMs: number;
+durationMs: number; 
 /**
  * Dominant language reported by the ASR backend (mode of
  * per-chunk languages). `None` until the first chunk lands.
  */
-language: string | null;
+language: string | null; 
 /**
  * Number of segments persisted.
  */
-segmentCount: number }) & {
+segmentCount: number }) & { 
 /**
  * Audio format negotiated with the device.
  */
-inputFormat: AudioFormat;
+inputFormat: AudioFormat; 
 /**
  * Decoded segments, ordered by `start_ms`. Each segment may
  * reference a `speaker_id` from `speakers`.
  */
-segments: Segment[];
+segments: Segment[]; 
 /**
  * Diarized speakers persisted for this meeting, ordered by
  * `slot`. Empty when no diarizer was wired into the pipeline.
@@ -588,19 +750,19 @@ export type MeetingId = string
  * boundaries are decided by SQLite's `snippet()` function and use
  * the markers chosen by the storage adapter — typically `<mark>` /
  * `</mark>` so the UI can render them as highlights.
- *
+ * 
  * `serde(rename_all = "camelCase")` keeps the wire format aligned
  * with the rest of the IPC surface.
  */
-export type MeetingSearchHit = {
+export type MeetingSearchHit = { 
 /**
  * Meeting matched by the query.
  */
-meeting: MeetingSummary;
+meeting: MeetingSummary; 
 /**
  * Highlighted excerpt of the segment that matched.
  */
-snippet: string;
+snippet: string; 
 /**
  * FTS5 BM25 rank — *smaller is better* (negative numbers are
  * strongest matches). The UI should sort ascending; tests assert
@@ -612,34 +774,34 @@ rank: number }
  * Lightweight projection used by listing endpoints. Holds only what
  * the UI needs to render a row in the sidebar — *not* the segments.
  */
-export type MeetingSummary = {
+export type MeetingSummary = { 
 /**
  * Stable identifier.
  */
-id: MeetingId;
+id: MeetingId; 
 /**
  * Human-readable title. Defaults to `"Meeting <date>"` when the
  * caller does not supply one.
  */
-title: string;
+title: string; 
 /**
  * RFC 3339 instant the recording started.
  */
-startedAt: string;
+startedAt: string; 
 /**
  * RFC 3339 instant the recording stopped. `None` while the
  * session is still running.
  */
-endedAt: string | null;
+endedAt: string | null; 
 /**
  * Total audio captured, in milliseconds.
  */
-durationMs: number;
+durationMs: number; 
 /**
  * Dominant language reported by the ASR backend (mode of
  * per-chunk languages). `None` until the first chunk lands.
  */
-language: string | null;
+language: string | null; 
 /**
  * Number of segments persisted.
  */
@@ -647,59 +809,59 @@ segmentCount: number }
 /**
  * A downloadable model known to the app.
  */
-export type ModelInfo = {
+export type ModelInfo = { 
 /**
  * Machine-readable id (e.g. `"asr-large-v3-turbo"`).
  */
-id: string;
+id: string; 
 /**
  * Human label shown in the UI.
  */
-label: string;
+label: string; 
 /**
  * Category: `"asr"`, `"llm"`, `"vad"`, or `"embedder"`.
  */
-kind: string;
+kind: string; 
 /**
  * Whether the file exists on disk right now.
  */
-present: boolean;
+present: boolean; 
 /**
  * Approximate download size in bytes (for progress UI).
  */
 sizeBytes: number }
 /**
  * One contiguous transcription span.
- *
+ * 
  * `serde(rename_all = "camelCase")` keeps the wire format aligned
  * with the TypeScript `Segment` type in `src/types/segment.ts`, so
  * the `Meeting` aggregate returned by `get_meeting` exposes
  * `startMs` (not `start_ms`) — the same convention the streaming
  * `Chunk` event already uses for the segments it carries.
  */
-export type Segment = {
+export type Segment = { 
 /**
  * Stable identifier.
  */
-id: SegmentId;
+id: SegmentId; 
 /**
  * Inclusive start offset, in milliseconds, relative to the
  * containing recording.
  */
-startMs: number;
+startMs: number; 
 /**
  * Exclusive end offset, in milliseconds. Always `>= start_ms`.
  */
-endMs: number;
+endMs: number; 
 /**
  * Decoded text. May be empty when the segment is silence or pure
  * non-speech but the ASR backend still emitted it.
  */
-text: string;
+text: string; 
 /**
  * Diarized speaker. `None` until diarization runs (Sprint 2).
  */
-speakerId: SpeakerId | null;
+speakerId: SpeakerId | null; 
 /**
  * Confidence in `[0.0, 1.0]`. `None` when the backend does not
  * report it (e.g. whisper.cpp without `temperature_inc`).
@@ -713,23 +875,23 @@ confidence: number | null }
 export type SegmentId = string
 /**
  * One clustered voice within a meeting.
- *
+ * 
  * `slot` is the 0-based index of the speaker within the meeting,
  * assigned in arrival order. It drives the UI palette and the
  * default display name; it is **not** the database primary key
  * (that's [`SpeakerId`]).
  */
-export type Speaker = {
+export type Speaker = { 
 /**
  * Stable identifier.
  */
-id: SpeakerId;
+id: SpeakerId; 
 /**
  * 0-based arrival order within the meeting. Drives the default
  * display name (`Speaker 1` for slot 0, etc.) and the color
  * palette index in the UI.
  */
-slot: number;
+slot: number; 
 /**
  * User-assigned label, if any. `None` ⇒ render as
  * "Speaker {slot+1}". Limited to 80 characters at the storage
@@ -745,31 +907,31 @@ export type SpeakerId = string
  * Options the frontend may pass when starting a streaming session.
  * All fields optional; defaults match `StreamingOptions::default()`.
  */
-export type StartStreamingOptions = {
+export type StartStreamingOptions = { 
 /**
  * Capture source. `None` ⇒ microphone, preserving Sprint 0
  * behavior. `systemOutput` requires macOS 13+ with Screen
  * Recording permission (Sprint 1 day 2/3).
  */
-source: IpcAudioSource | null;
+source: IpcAudioSource | null; 
 /**
  * ISO-639-1 language hint. `None` ⇒ auto-detect.
  */
-language: string | null;
+language: string | null; 
 /**
  * Capture device id. `None` ⇒ system default microphone. Ignored
  * when `source = systemOutput`.
  */
-deviceId: string | null;
+deviceId: string | null; 
 /**
  * Audio chunk size in milliseconds. `None` ⇒ 5000.
  */
-chunkMs: number | null;
+chunkMs: number | null; 
 /**
  * RMS threshold below which a chunk is reported as `Skipped`
  * instead of being sent to the ASR. `None` ⇒ 0.02.
  */
-silenceRmsThreshold: number | null;
+silenceRmsThreshold: number | null; 
 /**
  * Enable speaker diarization for this session. `None`/`false` ⇒
  * disabled (keeps Sprint 0 behaviour). When enabled the backend
@@ -778,13 +940,13 @@ silenceRmsThreshold: number | null;
  * so every emitted `Chunk` event carries `speakerId` +
  * `speakerSlot` and the meeting persists its speakers.
  */
-diarize: boolean | null;
+diarize: boolean | null; 
 /**
  * Override path to the speaker-embedder ONNX. `None` ⇒ use the
  * path resolved at app start. Mostly useful for tests / power
  * users; the UI does not surface it.
  */
-embedModelPath: string | null;
+embedModelPath: string | null; 
 /**
  * Disable the neural (Silero) VAD for this session and fall back
  * to the energy-based RMS gate. `None`/`false` ⇒ neural VAD is
@@ -802,14 +964,14 @@ disableNeuralVad: boolean | null }
 export type StreamingSessionId = string
 /**
  * A persisted LLM summary attached to a [`crate::Meeting`].
- *
+ * 
  * `serde(rename_all = "camelCase")` so the React layer can consume
  * `meetingId` / `createdAt` directly. The `content` field flattens
  * the [`SummaryContent`] enum so JSON readers see one combined
  * document instead of `{ "content": { … } }`, matching how the LLM
  * itself emits the structured output.
  */
-export type Summary =
+export type Summary = 
 /**
  * Structured payload — discriminated on `template`.
  */
@@ -817,54 +979,59 @@ export type Summary =
 /**
  * Default template — works for any meeting type (§3.2.1).
  */
-{ template: "general"; summary: string; key_points?: string[]; decisions?: string[]; action_items?: ActionItem[]; open_questions?: string[] } |
+{ template: "general"; summary: string; key_points?: string[]; decisions?: string[]; action_items?: ActionItem[]; open_questions?: string[] } | 
 /**
  * 1:1 meetings between manager and report (§3.2.2).
  */
-{ template: "oneOnOne"; summary: string; wins?: string[]; blockers?: string[]; growth_feedback?: string[]; next_steps?: ActionItem[]; follow_up_topics?: string[] } |
+{ template: "oneOnOne"; summary: string; wins?: string[]; blockers?: string[]; growth_feedback?: string[]; next_steps?: ActionItem[]; follow_up_topics?: string[] } | 
 /**
  * Sprint review / retrospective (§3.2.3).
  */
-{ template: "sprintReview"; summary: string; completed_items?: string[]; carry_over?: string[]; risks?: string[]; next_sprint_priorities?: string[] } |
+{ template: "sprintReview"; summary: string; completed_items?: string[]; carry_over?: string[]; risks?: string[]; next_sprint_priorities?: string[] } | 
 /**
  * User research or hiring interview (§3.2.4).
  */
-{ template: "interview"; summary: string; quotes?: InterviewQuote[]; themes?: string[]; pain_points?: string[]; opportunities?: string[] } |
+{ template: "interview"; summary: string; quotes?: InterviewQuote[]; themes?: string[]; pain_points?: string[]; opportunities?: string[] } | 
 /**
  * Sales / discovery call (§3.2.5).
  */
-{ template: "salesCall"; summary: string; customer_context?: string | null; pain_points?: string[]; interest_signals?: string[]; objections?: string[]; next_steps?: ActionItem[]; deal_stage_indicator?: string | null } |
+{ template: "salesCall"; summary: string; customer_context?: string | null; pain_points?: string[]; interest_signals?: string[]; objections?: string[]; next_steps?: ActionItem[]; deal_stage_indicator?: string | null } | 
 /**
  * Lecture, class, or workshop (§3.2.6).
  */
-{ template: "lecture"; summary: string; concepts_covered?: string[]; definitions?: Definition[]; examples?: string[]; homework_or_next?: string[] } |
+{ template: "lecture"; summary: string; concepts_covered?: string[]; definitions?: Definition[]; examples?: string[]; homework_or_next?: string[] } | 
 /**
  * Graceful degradation when JSON parsing fails twice.
  */
-{ template: "freeText"; text: string }) & {
+{ template: "freeText"; text: string } | 
+/**
+ * User-defined custom template. The `template_name` identifies
+ * which [`crate::CustomTemplate`] produced this summary.
+ */
+{ template: "custom"; template_name: string; text: string }) & { 
 /**
  * Stable identifier.
  */
-id: SummaryId;
+id: SummaryId; 
 /**
  * Owning meeting. Each meeting may carry at most one summary
  * per template at a time — re-running the summarizer
  * overwrites the previous one (the SQLite adapter enforces
  * this with a unique index).
  */
-meetingId: MeetingId;
+meetingId: MeetingId; 
 /**
  * LLM model identifier (e.g. `"qwen2.5-7b-instruct-q4_k_m"`).
  * Stored alongside the content so a future "regenerate with
  * model X" flow can compare provenance.
  */
-model: string;
+model: string; 
 /**
  * ISO-639-1 language the summary was produced in. Echoes the
  * transcript's dominant language; the LLM is instructed to
  * answer in that language.
  */
-language: string | null;
+language: string | null; 
 /**
  * RFC 3339 instant the summary finished generating.
  */
@@ -877,33 +1044,33 @@ createdAt: string }
 export type SummaryId = string
 /**
  * One event emitted by the streaming pipeline.
- *
+ * 
  * The variant order on the wire intentionally matches the lifecycle:
  * `Started` → 0..N × `Chunk` → optional `Skipped` mixed in →
  * `Stopped` | `Failed`.
- *
+ * 
  * Wire format: tagged with `type` (lowercase) and field names in
  * `camelCase` for ergonomic consumption from TypeScript.
  */
-export type TranscriptEvent =
+export type TranscriptEvent = 
 /**
  * Capture has begun. Reports the negotiated input format.
  */
-{ type: "started"; sessionId: StreamingSessionId; inputFormat: AudioFormat } |
+{ type: "started"; sessionId: StreamingSessionId; inputFormat: AudioFormat } | 
 /**
  * One transcribed chunk. Segments inside are timestamped relative
  * to the start of the session (not the chunk).
  */
-{ type: "chunk"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; segments: Segment[]; language: string | null; rtf: number; speakerId?: SpeakerId | null; speakerSlot?: number | null } |
+{ type: "chunk"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; segments: Segment[]; language: string | null; rtf: number; speakerId?: SpeakerId | null; speakerSlot?: number | null } | 
 /**
  * A chunk was discarded by the silence gate before being sent to
  * the ASR backend. Useful for UI / metrics.
  */
-{ type: "skipped"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; durationMs: number; rms: number } |
+{ type: "skipped"; sessionId: StreamingSessionId; chunkIndex: number; offsetMs: number; durationMs: number; rms: number } | 
 /**
  * The pipeline finished cleanly (caller stopped or stream EOF).
  */
-{ type: "stopped"; sessionId: StreamingSessionId; totalSegments: number; totalAudioMs: number } |
+{ type: "stopped"; sessionId: StreamingSessionId; totalSegments: number; totalAudioMs: number } | 
 /**
  * The pipeline aborted with an error. No further events follow.
  */
@@ -934,8 +1101,8 @@ export type Result<T, E> =
 	| { status: "ok"; data: T }
 	| { status: "error"; error: E };
 
-// @ts-ignore auto-generated by tauri-specta
-function __makeEvents__<T extends Record<string, any>>(
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function __makeEvents__<T extends Record<string, any>>(
 	mappings: Record<keyof T, string>,
 ) {
 	return new Proxy(

--- a/src/ipc/client.ts
+++ b/src/ipc/client.ts
@@ -30,6 +30,7 @@ import type {
   TranscriptEvent,
 } from "../types/streaming";
 import type { Summary } from "../types/summary";
+import type { CustomTemplate, CustomTemplateId } from "../types/custom-template";
 
 // ---------------------------------------------------------------------------
 // Health
@@ -222,6 +223,70 @@ export async function cancelDownload(modelId: string): Promise<boolean> {
 /** Delete a downloaded model from disk. */
 export async function deleteModel(modelId: string): Promise<void> {
   return invoke<void>("delete_model", { modelId });
+}
+
+/** Set the active LLM model. Unloads the current model first. */
+export async function setActiveLlm(modelId: string): Promise<void> {
+  return invoke<void>("set_active_llm", { modelId });
+}
+
+/** Get the currently active LLM model id, or null. */
+export async function getActiveLlm(): Promise<string | null> {
+  return invoke<string | null>("get_active_llm");
+}
+
+/** Set the active ASR (speech recognition) model. Unloads the current transcriber first. */
+export async function setActiveAsr(modelId: string): Promise<void> {
+  return invoke<void>("set_active_asr", { modelId });
+}
+
+/** Get the currently active ASR model id, or null. */
+export async function getActiveAsr(): Promise<string | null> {
+  return invoke<string | null>("get_active_asr");
+}
+
+// ---------------------------------------------------------------------------
+// Custom templates (user-defined summary prompts)
+// ---------------------------------------------------------------------------
+
+/** List all user-defined custom templates. */
+export async function listCustomTemplates(): Promise<CustomTemplate[]> {
+  return invoke<CustomTemplate[]>("list_custom_templates");
+}
+
+/** Create a new custom template. */
+export async function createCustomTemplate(
+  name: string,
+  prompt: string,
+): Promise<CustomTemplate> {
+  return invoke<CustomTemplate>("create_custom_template", { name, prompt });
+}
+
+/** Update an existing custom template. */
+export async function updateCustomTemplate(
+  id: CustomTemplateId,
+  name: string,
+  prompt: string,
+): Promise<CustomTemplate> {
+  return invoke<CustomTemplate>("update_custom_template", { id, name, prompt });
+}
+
+/** Delete a custom template by id. */
+export async function deleteCustomTemplate(
+  id: CustomTemplateId,
+): Promise<void> {
+  return invoke<void>("delete_custom_template", { id });
+}
+
+/** Generate a summary using a custom template. */
+export async function summarizeWithCustomTemplate(
+  meetingId: MeetingId,
+  templateId: CustomTemplateId,
+): Promise<Summary> {
+  return invoke<Summary>("summarize_with_custom_template", {
+    meetingId,
+    templateId,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/custom-template.ts
+++ b/src/types/custom-template.ts
@@ -1,0 +1,12 @@
+/** Opaque identifier for a user-defined custom template. */
+export type CustomTemplateId = string;
+
+/** A user-defined summary prompt template. */
+export interface CustomTemplate {
+  /** Stable UUID identifier. */
+  id: CustomTemplateId;
+  /** Short display name (e.g. "Product Standup"). */
+  name: string;
+  /** System-prompt text sent to the LLM. */
+  prompt: string;
+}

--- a/src/types/summary.ts
+++ b/src/types/summary.ts
@@ -109,6 +109,13 @@ export type FreeTextSummary = {
   text: string;
 };
 
+/** User-defined custom template output. */
+export type CustomSummary = {
+  template: "custom";
+  templateName: string;
+  text: string;
+};
+
 /** Discriminated union of every supported summary template. */
 export type SummaryContent =
   | GeneralSummary
@@ -117,7 +124,8 @@ export type SummaryContent =
   | InterviewSummary
   | SalesCallSummary
   | LectureSummary
-  | FreeTextSummary;
+  | FreeTextSummary
+  | CustomSummary;
 
 /** User-facing template identifiers (excludes freeText). */
 export const TEMPLATE_IDS = [


### PR DESCRIPTION
## Summary

Adds two major features for v0.3.0:

### Custom Summary Templates
- Full CRUD for user-defined summary prompt templates
- Templates stored as JSON in app data directory (`custom_templates.json`)
- New `TemplateManager` modal UI accessible from the Summary panel (gear icon)
- Backend: `CustomTemplate` domain entity, `templates.rs` commands, `summarize_with_custom_template` IPC
- Frontend: Template selector in `SummaryPanel` with custom optgroup, `TemplateManager.tsx` component

### Runtime Model Selection (ASR + LLM)
- Switch active ASR and LLM models at runtime without restarting
- `model_path` and `llm_model_path` in `AppState` changed from `PathBuf` to `RwLock<PathBuf>`
- `LazyModel<T>.unload()` forces reload on next use after switching
- New IPC commands: `set_active_llm`, `get_active_llm`, `set_active_asr`, `get_active_asr`
- `ModelManager` UI shows "Use" button and "Active" badge for ASR and LLM models

### Other
- Version bump: `0.2.2` → `0.3.0`
- Added `custom_templates.json` to `.gitignore`
- i18n keys for both EN and ES
- Fixed `exactOptionalPropertyTypes` issues in ModelManager
- Fixed auto-generated `bindings.ts` conflicts