### PR TITLE
chore: add CLA document and GitHub Action workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,36 @@
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: "signatures/cla.json"
+          path-to-document: "https://github.com/luismctech/echonote/blob/main/CLA.md"
+          branch: "main"
+          allowlist: "luismctech,dependabot[bot],renovate[bot],bot*"
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge this PR, you need to sign our [Contributor License Agreement](https://github.com/luismctech/echonote/blob/main/CLA.md).
+
+            To sign, please post the following comment:
+
+            > I have read the CLA Document and I hereby sign the CLA
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "All contributors have signed the CLA. Thank you!"
+          lock-pullrequest-aftermerge: true

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,55 @@
+# EchoNote Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to **EchoNote** ("the Project"),
+maintained by **Luis MC** ("the Maintainer").
+
+By signing this CLA, you agree to the following terms for your present and
+future contributions to the Project.
+
+## 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including
+  modifications or additions to existing work, that you submit to the Project
+  via pull request, issue, or any other method.
+
+- **"You"** (or **"Contributor"**) means the individual or legal entity making
+  the Contribution.
+
+## 2. Grant of Rights
+
+You hereby grant to the Maintainer:
+
+- A **perpetual, worldwide, non-exclusive, royalty-free, irrevocable** license
+  to use, reproduce, modify, display, perform, sublicense, and distribute your
+  Contributions as part of the Project.
+
+- The right to **relicense** your Contributions under any license the
+  Maintainer chooses, including proprietary or commercial licenses.
+
+## 3. Original Work
+
+You represent that each Contribution is your original creation and that you
+have the legal right to grant the above license. If your employer has rights to
+intellectual property that you create, you represent that you have received
+permission to make Contributions on behalf of that employer.
+
+## 4. No Obligation
+
+The Maintainer is not obligated to use, merge, or include any Contribution.
+
+## 5. Project License
+
+The Project is currently licensed under the
+[PolyForm Noncommercial License 1.0.0](./LICENSE). This CLA allows the
+Maintainer to offer the Project (including your Contributions) under
+additional licenses, including commercial licenses, without further
+permission from you.
+
+## 6. How to Sign
+
+You sign this CLA by posting the following comment on a pull request to this
+repository:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature will be recorded automatically via GitHub Actions.


### PR DESCRIPTION
## Summary

Sets up a Contributor License Agreement (CLA) for the project so that external contributions grant relicensing rights to the maintainer.

### Changes

- **`CLA.md`** — Individual CLA document. Contributors grant a perpetual, non-exclusive license with sublicensing rights (including commercial). Contributors retain their own copyright.
- **`.github/workflows/cla.yml`** — CLA Assistant Lite GitHub Action that:
  - Automatically comments on PRs from new contributors asking them to sign
  - Records signatures in `signatures/cla.json`
  - Locks PR conversations after merge to prevent signature revocation
  - Auto-allowlists the owner (`luismctech`) and bots (`dependabot[bot]`, `renovate[bot]`)

### Why

The project uses [PolyForm Noncommercial 1.0.0](./LICENSE). Without a CLA, contributors retain copyright on their code, which would prevent the maintainer from offering commercial licenses for the combined work.