### PR TITLE
feat: ASR improvements, hardware-aware model recommendations & dock fix

### DIFF
--- a/crates/echo-app/src/lib.rs
+++ b/crates/echo-app/src/lib.rs
@@ -12,10 +12,12 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, clippy::all)]
 
+pub mod punct;
 pub mod sanitize;
 pub mod services;
 pub mod use_cases;
 
+pub use punct::NaivePunctuator;
 pub use services::meeting_recorder::MeetingRecorder;
 pub use services::wer::{compute as compute_wer, normalize as normalize_for_wer, WerStats};
 pub use use_cases::chat_with_transcript::{

--- a/crates/echo-app/src/punct.rs
+++ b/crates/echo-app/src/punct.rs
@@ -1,0 +1,242 @@
+//! Rule-based punctuation restoration.
+//!
+//! [`NaivePunctuator`] is a zero-dependency, always-available fallback
+//! that handles the most common deficiencies in raw Whisper output:
+//!
+//! 1. **Missing terminal punctuation** — adds `.` (or `?` for detected
+//!    questions) when the segment ends without `.`, `!`, `?`, `…`, `:`,
+//!    or `;`.
+//! 2. **Lower-case first letter** — capitalises the first character of
+//!    each segment so that segments can be read independently of context.
+//!
+//! ## What it intentionally does NOT do
+//!
+//! - Insert commas mid-sentence — too error-prone without a language model.
+//! - Rewrite existing punctuation — if Whisper already added `.` we trust it.
+//! - Change any word — semantics are untouched.
+//!
+//! ## Question detection heuristics
+//!
+//! English: segment starts with a known interrogative/auxiliary verb
+//! (`who`, `what`, `when`, `where`, `why`, `how`, `is`, `are`, …).
+//!
+//! Spanish: segment starts with `¿` (already a question opener) or with
+//! a known interrogative word with or without written accent.
+
+use echo_domain::Punctuator;
+
+/// Zero-dependency, rule-based punctuation restorer.
+///
+/// Thread-safe: holds no mutable state. Cheap to clone or share via
+/// `Arc<NaivePunctuator>`.
+#[derive(Debug, Clone, Default)]
+pub struct NaivePunctuator;
+
+impl Punctuator for NaivePunctuator {
+    fn punctuate(&self, text: &str, language: Option<&str>) -> String {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return String::new();
+        }
+
+        // If the segment already ends with terminal punctuation, only
+        // ensure the first character is capitalised.
+        if ends_with_terminal(trimmed) {
+            return capitalize_first(trimmed);
+        }
+
+        let capitalized = capitalize_first(trimmed);
+        if is_question(trimmed, language) {
+            format!("{capitalized}?")
+        } else {
+            format!("{capitalized}.")
+        }
+    }
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn ends_with_terminal(s: &str) -> bool {
+    matches!(s.chars().last(), Some('.' | '!' | '?' | '…' | ':' | ';'))
+}
+
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+fn is_question(text: &str, language: Option<&str>) -> bool {
+    // Spanish inverted question mark is an unambiguous signal.
+    if text.starts_with('¿') {
+        return true;
+    }
+
+    let lower = text.to_lowercase();
+    let words: Vec<&str> = lower.split_whitespace().collect();
+    if words.is_empty() {
+        return false;
+    }
+
+    let lang = language.unwrap_or("en");
+
+    if lang.starts_with("es") {
+        is_spanish_question(&words)
+    } else {
+        is_english_question(&words)
+    }
+}
+
+fn is_english_question(words: &[&str]) -> bool {
+    const INTERROGATIVES: &[&str] = &[
+        "who", "what", "when", "where", "why", "how", "which", "whose", "whom",
+    ];
+    const AUXILIARIES: &[&str] = &[
+        "is",
+        "are",
+        "was",
+        "were",
+        "am",
+        "do",
+        "does",
+        "did",
+        "can",
+        "could",
+        "would",
+        "should",
+        "will",
+        "shall",
+        "have",
+        "has",
+        "had",
+        "may",
+        "might",
+        "isn't",
+        "aren't",
+        "wasn't",
+        "weren't",
+        "don't",
+        "doesn't",
+        "didn't",
+        "can't",
+        "couldn't",
+        "wouldn't",
+        "shouldn't",
+        "won't",
+    ];
+    let first = words.first().copied().unwrap_or("");
+    INTERROGATIVES.contains(&first) || AUXILIARIES.contains(&first)
+}
+
+fn is_spanish_question(words: &[&str]) -> bool {
+    const SINGLE: &[&str] = &[
+        // with accent (Whisper usually outputs these)
+        "quién", "quiénes", "qué", "cuándo", "dónde", "cómo", "cuál", "cuáles", "cuánto", "cuánta",
+        "cuántos", "cuántas",
+        // without accent (fallback for models that strip diacritics)
+        "quien", "quienes", "que", "cuando", "donde", "como", "cual", "cuales", "cuanto", "cuanta",
+        "cuantos", "cuantas",
+    ];
+    const DOUBLE_FIRST: &[&str] = &["por", "en", "de", "a", "para", "desde", "hasta", "con"];
+
+    let first = words.first().copied().unwrap_or("");
+    let second = words.get(1).copied().unwrap_or("");
+
+    if SINGLE.contains(&first) {
+        return true;
+    }
+    // "por qué / en qué / de qué / a quién" etc.
+    if DOUBLE_FIRST.contains(&first) {
+        let candidates = ["qué", "que", "quién", "quien", "quiénes", "quienes"];
+        if candidates.contains(&second) {
+            return true;
+        }
+    }
+    false
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use echo_domain::Punctuator;
+
+    fn p(text: &str, lang: &str) -> String {
+        NaivePunctuator.punctuate(text, Some(lang))
+    }
+
+    #[test]
+    fn adds_period_to_unpunctuated_statement() {
+        assert_eq!(p("hello world", "en"), "Hello world.");
+        assert_eq!(
+            p("the meeting starts at nine", "en"),
+            "The meeting starts at nine."
+        );
+    }
+
+    #[test]
+    fn adds_question_mark_to_english_question() {
+        assert_eq!(
+            p("what time is the meeting", "en"),
+            "What time is the meeting?"
+        );
+        assert_eq!(
+            p("how are you doing today", "en"),
+            "How are you doing today?"
+        );
+        assert_eq!(p("is the report ready", "en"), "Is the report ready?");
+        assert_eq!(
+            p("can you send me the file", "en"),
+            "Can you send me the file?"
+        );
+    }
+
+    #[test]
+    fn does_not_alter_already_punctuated_text() {
+        assert_eq!(p("Hello world.", "en"), "Hello world.");
+        assert_eq!(p("Are you sure?", "en"), "Are you sure?");
+        assert_eq!(p("Watch out!", "en"), "Watch out!");
+    }
+
+    #[test]
+    fn capitalises_first_letter() {
+        assert_eq!(p("the quick brown fox", "en"), "The quick brown fox.");
+    }
+
+    #[test]
+    fn adds_question_mark_to_spanish_question_with_inverted_mark() {
+        assert_eq!(p("¿cómo estás", "es"), "¿cómo estás?");
+    }
+
+    #[test]
+    fn adds_question_mark_to_spanish_interrogative() {
+        assert_eq!(p("cómo estás hoy", "es"), "Cómo estás hoy?");
+        assert_eq!(p("qué hora es", "es"), "Qué hora es?");
+        assert_eq!(p("por qué no viniste", "es"), "Por qué no viniste?");
+    }
+
+    #[test]
+    fn adds_period_to_spanish_statement() {
+        assert_eq!(
+            p("la reunión empieza a las nueve", "es"),
+            "La reunión empieza a las nueve."
+        );
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(p("", "en"), "");
+        assert_eq!(p("   ", "en"), "");
+    }
+
+    #[test]
+    fn handles_unknown_language_as_english() {
+        assert_eq!(
+            NaivePunctuator.punctuate("what is this", None),
+            "What is this?"
+        );
+    }
+}

--- a/crates/echo-app/src/use_cases/streaming/mod.rs
+++ b/crates/echo-app/src/use_cases/streaming/mod.rs
@@ -32,9 +32,9 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
 use echo_domain::{
-    AudioCapture, AudioFormat, CaptureSpec, Diarizer, DomainError, Resampler, Sample, SpeakerId,
-    StreamingOptions, StreamingSessionId, TranscribeOptions, Transcriber, TranscriptEvent, Vad,
-    VoiceState,
+    AudioCapture, AudioFormat, CaptureSpec, Diarizer, DomainError, Punctuator, Resampler, Sample,
+    SpeakerId, StreamingOptions, StreamingSessionId, TranscribeOptions, Transcriber,
+    TranscriptEvent, Vad, VoiceState,
 };
 
 /// Capacity of the event channel. ~10 minutes of headroom for a
@@ -82,6 +82,11 @@ pub struct StreamingPipeline {
     /// pipeline must feed it every chunk for its temporal model to
     /// stay coherent.
     vad: Option<Box<dyn Vad>>,
+    /// Optional punctuation restorer applied to every segment text
+    /// after transcription. When `None` segments are emitted as-is
+    /// (Whisper large-v3-turbo produces reasonable punctuation on its
+    /// own; the restorer is most valuable for small/fast models).
+    punctuator: Option<Arc<dyn Punctuator>>,
 }
 
 impl StreamingPipeline {
@@ -97,6 +102,7 @@ impl StreamingPipeline {
             transcriber,
             diarizer: None,
             vad: None,
+            punctuator: None,
         }
     }
 
@@ -119,6 +125,15 @@ impl StreamingPipeline {
     #[must_use]
     pub fn with_vad(mut self, vad: Box<dyn Vad>) -> Self {
         self.vad = Some(vad);
+        self
+    }
+
+    /// Attach a punctuation restorer. Applied to every segment text
+    /// after transcription succeeds. Useful with small/fast models
+    /// whose raw output lacks consistent punctuation.
+    #[must_use]
+    pub fn with_punctuator(mut self, punctuator: Arc<dyn Punctuator>) -> Self {
+        self.punctuator = Some(punctuator);
         self
     }
 
@@ -168,6 +183,7 @@ impl StreamingPipeline {
             self.transcriber,
             self.diarizer,
             self.vad,
+            self.punctuator,
             session_id,
             spec,
             options,
@@ -272,6 +288,7 @@ async fn run_pipeline(
     transcriber: Arc<dyn Transcriber>,
     mut diarizer: Option<Box<dyn Diarizer>>,
     mut vad: Option<Box<dyn Vad>>,
+    punctuator: Option<Arc<dyn Punctuator>>,
     session_id: StreamingSessionId,
     spec: CaptureSpec,
     options: StreamingOptions,
@@ -378,6 +395,7 @@ async fn run_pipeline(
                 &transcriber,
                 &mut diarizer,
                 &mut vad,
+                punctuator.as_deref(),
                 session_id,
                 chunk_index,
                 offset_ms,
@@ -409,6 +427,7 @@ async fn run_pipeline(
             &transcriber,
             &mut diarizer,
             &mut vad,
+            punctuator.as_deref(),
             session_id,
             chunk_index,
             offset_ms,
@@ -446,6 +465,7 @@ async fn process_chunk(
     transcriber: &Arc<dyn Transcriber>,
     diarizer: &mut Option<Box<dyn Diarizer>>,
     vad: &mut Option<Box<dyn Vad>>,
+    punctuator: Option<&dyn Punctuator>,
     session_id: StreamingSessionId,
     chunk_index: u32,
     offset_ms: u32,
@@ -535,6 +555,15 @@ async fn process_chunk(
 
     match result {
         Ok(mut transcript) => {
+            // Apply punctuation restoration before emitting so consumers
+            // receive clean, consistently-punctuated text regardless of
+            // which ASR model was active.
+            if let Some(p) = punctuator {
+                let lang = transcript.language.as_deref();
+                for seg in &mut transcript.segments {
+                    seg.text = p.punctuate(&seg.text, lang);
+                }
+            }
             // Make segment timestamps absolute relative to the session start.
             for seg in &mut transcript.segments {
                 seg.start_ms = seg.start_ms.saturating_add(offset_ms);

--- a/crates/echo-asr/src/whisper_cpp.rs
+++ b/crates/echo-asr/src/whisper_cpp.rs
@@ -247,12 +247,39 @@ fn run_full(
         let seg = state.get_segment(i).ok_or_else(|| {
             DomainError::Invariant(format!("whisper segment {i} reported but missing"))
         })?;
+
+        // ── Filter 1: no-speech probability ─────────────────────────
+        // whisper-rs note: set_no_speech_thold() is documented as "not
+        // implemented" in whisper.cpp ≤ v1.3 — the param exists but is
+        // not enforced by the engine. We therefore apply the threshold
+        // post-hoc on the segment-level probability the model emits.
+        // 0.6 catches residual hallucinations that survive the existing
+        // entropy / logprob guards without being too aggressive on real
+        // speech fragments with low acoustic confidence.
+        let no_speech_prob = seg.no_speech_probability();
+        if no_speech_prob > NO_SPEECH_POST_THOLD {
+            debug!(no_speech_prob, "dropping high-no-speech-prob segment");
+            continue;
+        }
+
         let text = seg.to_str_lossy().map_err(map_whisper_err)?.into_owned();
-        // Drop canonical YouTube/Amara outros — see `is_known_hallucination`.
+
+        // ── Filter 2: known-hallucination phrase list ────────────────
         if is_known_hallucination(&text) {
             debug!(text = %text, "dropping known whisper hallucination");
             continue;
         }
+
+        // ── Filter 3: greedy repetition-loop detection ───────────────
+        // At temperature = 0 the greedy decoder can get stuck repeating
+        // the same word or phrase. `is_repetitive_loop` catches these
+        // collapsed outputs (4+ consecutive repetitions of an n-gram)
+        // before they reach the transcript.
+        if is_repetitive_loop(&text) {
+            debug!(text = %text, "dropping repetitive-loop segment");
+            continue;
+        }
+
         // whisper.cpp returns timestamps in centiseconds (10 ms units).
         let start_ms = (seg.start_timestamp().max(0) as u32).saturating_mul(10);
         let end_ms = (seg.end_timestamp().max(0) as u32).saturating_mul(10);
@@ -291,6 +318,16 @@ fn run_full(
     })
 }
 
+/// Post-hoc no-speech probability threshold applied per segment after
+/// `state.full()` returns. Segments whose `no_speech_prob` exceeds this
+/// are dropped before they reach the transcript.
+///
+/// Rationale: `set_no_speech_thold` in whisper.cpp ≤ v1.3 is documented
+/// as "not implemented" — the engine does not enforce it, so we must
+/// apply the gate ourselves. 0.6 is deliberately conservative: it only
+/// drops segments the model itself rates as very likely non-speech.
+const NO_SPEECH_POST_THOLD: f32 = 0.6;
+
 fn map_whisper_err(err: WhisperError) -> DomainError {
     DomainError::Invariant(format!("whisper.cpp: {err}"))
 }
@@ -317,6 +354,43 @@ fn install_logging_hooks_once() {
     INIT.get_or_init(|| {
         install_logging_hooks();
     });
+}
+
+/// Return `true` when `text` shows signs of a greedy decoder repetition
+/// loop: any word-level n-gram (size 1–3) that appears **4 or more
+/// consecutive times** in the same segment.
+///
+/// Example pathological outputs this catches:
+/// - "Thank you thank you thank you thank you thank you"
+/// - "the the the the the the meeting"
+/// - "I think I think I think I think so"
+///
+/// Minimum segment length: 4 words (shorter segments are never loops).
+fn is_repetitive_loop(text: &str) -> bool {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    let n = words.len();
+    if n < 4 {
+        return false;
+    }
+    for gram_size in 1..=3_usize {
+        if gram_size * 4 > n {
+            break;
+        }
+        let mut i = 0;
+        while i + gram_size * 4 <= n {
+            let mut reps = 0usize;
+            let mut j = i;
+            while j + gram_size <= n && words[j..j + gram_size] == words[i..i + gram_size] {
+                reps += 1;
+                j += gram_size;
+            }
+            if reps >= 4 {
+                return true;
+            }
+            i += 1;
+        }
+    }
+    false
 }
 
 /// Return `true` when `text` is one of the canonical phrases Whisper
@@ -403,7 +477,7 @@ fn is_known_hallucination(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_known_hallucination;
+    use super::{is_known_hallucination, is_repetitive_loop};
 
     #[test]
     fn drops_canonical_spanish_youtube_outros() {
@@ -471,6 +545,41 @@ mod tests {
         ));
         assert!(is_known_hallucination("silence."));
         assert!(is_known_hallucination("Música"));
+    }
+
+    #[test]
+    fn detects_single_word_loop() {
+        assert!(is_repetitive_loop("the the the the"));
+        assert!(is_repetitive_loop(
+            "thank you thank you thank you thank you"
+        ));
+    }
+
+    #[test]
+    fn detects_bigram_loop() {
+        assert!(is_repetitive_loop(
+            "I think I think I think I think so maybe"
+        ));
+        assert!(is_repetitive_loop(
+            "thank you thank you thank you thank you very much"
+        ));
+    }
+
+    #[test]
+    fn keeps_legitimate_speech_with_repetition() {
+        // Natural repetition under the threshold.
+        assert!(!is_repetitive_loop("yes yes I agree yes"));
+        assert!(!is_repetitive_loop("very very good"));
+        assert!(!is_repetitive_loop(
+            "he said that that was not the right answer"
+        ));
+    }
+
+    #[test]
+    fn short_segments_never_loop() {
+        assert!(!is_repetitive_loop(""));
+        assert!(!is_repetitive_loop("ok"));
+        assert!(!is_repetitive_loop("thank you"));
     }
 
     #[test]

--- a/crates/echo-domain/src/lib.rs
+++ b/crates/echo-domain/src/lib.rs
@@ -28,6 +28,7 @@ pub use ports::audio::{
 pub use ports::chat::{ChatAssistant, ChatMessage, ChatOptions, ChatRequest, ChatRole, ChatToken};
 pub use ports::diarizer::Diarizer;
 pub use ports::llm::{GenerateOptions, LlmModel};
+pub use ports::punctuator::Punctuator;
 pub use ports::resampler::Resampler;
 pub use ports::segmenter::{Segmenter, SpeakerSegment};
 pub use ports::transcriber::{TranscribeOptions, Transcriber, Transcript};

--- a/crates/echo-domain/src/ports/mod.rs
+++ b/crates/echo-domain/src/ports/mod.rs
@@ -11,6 +11,7 @@ pub mod audio;
 pub mod chat;
 pub mod diarizer;
 pub mod llm;
+pub mod punctuator;
 pub mod resampler;
 pub mod segmenter;
 pub mod storage;

--- a/crates/echo-domain/src/ports/punctuator.rs
+++ b/crates/echo-domain/src/ports/punctuator.rs
@@ -1,0 +1,21 @@
+//! Punctuation restoration port.
+//!
+//! [`Punctuator`] takes raw ASR text (which may lack terminal punctuation
+//! or proper capitalisation) and returns a corrected version. Adapters
+//! range from simple rule-based heuristics to neural ONNX models.
+
+/// Synchronous, infallible punctuation corrector.
+///
+/// Implementations must be `Send + Sync` so they can be held behind an
+/// `Arc` and called from async contexts.
+pub trait Punctuator: Send + Sync {
+    /// Return a punctuated and capitalised version of `text`.
+    ///
+    /// - `text`     — raw ASR segment text, possibly already punctuated.
+    /// - `language` — ISO-639-1 hint (e.g. `"en"`, `"es"`). `None`
+    ///   means unknown; implementations should default to English.
+    ///
+    /// Implementations **must not** alter semantics: only add/correct
+    /// punctuation and capitalisation; never change words.
+    fn punctuate(&self, text: &str, language: Option<&str>) -> String;
+}

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -165,7 +165,38 @@ fn detect_claude_desktop() -> bool {
 }
 
 fn detect_claude_code() -> bool {
-    which_exists("claude")
+    // GUI apps on macOS don't inherit the user's shell PATH, so `which` misses
+    // binaries installed in user-local directories like ~/.local/bin. Check the
+    // known installation paths first, then fall back to `which` for edge cases.
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(h) = home() {
+            // npm / official installer puts the binary here
+            if h.join(".local/bin/claude").exists() {
+                return true;
+            }
+            // Claude Code also creates this directory for its own data
+            if h.join(".local/share/claude").exists() {
+                return true;
+            }
+        }
+        // Homebrew or manual install
+        if PathBuf::from("/opt/homebrew/bin/claude").exists()
+            || PathBuf::from("/usr/local/bin/claude").exists()
+        {
+            return true;
+        }
+        which_exists("claude")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        if let Some(h) = home() {
+            if h.join(".local/bin/claude").exists() {
+                return true;
+            }
+        }
+        which_exists("claude")
+    }
 }
 
 fn detect_vscode() -> bool {

--- a/src-tauri/src/commands/recommendation.rs
+++ b/src-tauri/src/commands/recommendation.rs
@@ -2,6 +2,28 @@
 //!
 //! Scores each model against the detected hardware and returns
 //! the recommended model for both ASR and LLM tasks.
+//!
+//! ## Decision logic
+//!
+//! The engine uses four hardware signals ranked by importance:
+//! 1. Total RAM — primary gate for which models can run at all.
+//! 2. Apple Silicon (`cpu_brand` contains "Apple M" + `unified_memory`) —
+//!    unlocks Metal-accelerated full-precision models at lower RAM thresholds.
+//! 3. Metal working set (`gpu_max_working_set`) — how much the GPU can
+//!    actively hold; used to size LLM recommendations on Apple Silicon.
+//! 4. Available RAM — if the system is already under pressure, add a warning.
+//!
+//! ## Memory budgets used
+//!
+//! | Model                  | ~RAM at inference |
+//! |------------------------|-------------------|
+//! | asr-base               |  160 MB           |
+//! | asr-small              |  500 MB           |
+//! | asr-large-v3-turbo-q5  |  620 MB           |
+//! | asr-large-v3-turbo     |  1.7 GB           |
+//! | llm-qwen3-4b Q4_K_M   |  3.0 GB           |
+//! | llm-qwen3-8b Q4_K_M   |  5.5 GB           |
+//! | llm-qwen3-14b Q4_K_M  |  9.5 GB           |
 
 use serde::Serialize;
 
@@ -53,68 +75,240 @@ pub fn get_model_recommendation() -> ModelRecommendation {
 }
 
 fn recommend(ram_gb: u64, hw: &HardwareProfile) -> (ModelPick, Option<ModelPick>, Option<String>) {
+    // Apple Silicon: unified memory pool shared by CPU + Metal GPU.
+    // Parse the brand string so that other vendors with unified_memory=true
+    // (AMD APUs, etc.) are not incorrectly treated as Apple Silicon.
+    let is_apple_silicon = hw.unified_memory && hw.cpu_brand.contains("Apple M");
+
+    // Metal working set in GiB — the actual capacity available to the GPU.
+    // M1 Pro 16 GB → ~10.7 GB; M1 8 GB → ~5.3 GB; M2 Max 32 GB → ~21.3 GB.
+    let metal_gb = hw.gpu_max_working_set / GB;
+
+    // Available RAM signal: warns when the OS is already under pressure.
+    // Only meaningful on non-unified platforms (macOS compresses aggressively
+    // so available RAM fluctuates a lot even when the system is healthy).
+    let available_gb = hw.available_ram_bytes / GB;
+    let memory_pressure = !is_apple_silicon && available_gb < 3;
+
     match ram_gb {
+        // ── ≤ 5 GB: transcription only ───────────────────────────────────────
         0..=5 => (
             ModelPick {
                 model_id: "asr-base".into(),
-                reason: "Very limited RAM — only the smallest model fits safely".into(),
+                reason: "Very limited RAM — only the smallest Whisper model (~148 MB) fits safely"
+                    .into(),
                 confidence: "high".into(),
             },
             None,
             Some(
-                "System RAM is very low. LLM features (summaries, chat) are not recommended."
+                "System RAM is too low for LLM features (summaries, chat). \
+                 Transcription only."
                     .into(),
             ),
         ),
-        6..=9 => (
-            ModelPick {
-                model_id: "asr-large-v3-turbo-q5".into(),
-                reason: "Good quality-to-size ratio for 8 GB systems".into(),
-                confidence: "high".into(),
-            },
-            Some(ModelPick {
-                model_id: "llm-qwen3-4b".into(),
-                reason: "Only 2.5 GB on disk (~3.5 GB RAM) — leaves headroom for ASR and OS".into(),
-                confidence: "high".into(),
-            }),
-            Some("With 8 GB RAM, the 4B model is recommended to avoid memory pressure.".into()),
-        ),
-        10..=19 => {
-            let asr = if hw.unified_memory && hw.cpu_cores >= 8 {
-                ModelPick {
-                    model_id: "asr-large-v3-turbo".into(),
-                    reason: "Unified memory + multi-core allows full-precision turbo model".into(),
-                    confidence: "high".into(),
-                }
+
+        // ── 6-9 GB (e.g. 8 GB MacBook M1/M2, 8 GB Windows laptop) ──────────
+        6..=9 => {
+            let (asr_reason, llm_reason) = if is_apple_silicon {
+                (
+                    "Quantized turbo (~620 MB) runs via Metal on Apple Silicon 8 GB".into(),
+                    "2.5 GB on disk; with macOS memory compression fits alongside Whisper".into(),
+                )
             } else {
-                ModelPick {
-                    model_id: "asr-large-v3-turbo-q5".into(),
-                    reason: "Quantized turbo model balances quality and memory usage".into(),
-                    confidence: "high".into(),
-                }
+                (
+                    "Good quality-to-size ratio for 8 GB systems".into(),
+                    "Only 2.5 GB on disk (~3 GB RAM) — leaves headroom for ASR and OS".into(),
+                )
+            };
+            let warn = if is_apple_silicon {
+                Some(
+                    "Running ASR + LLM simultaneously uses ~4 GB of your 8 GB. \
+                     Close other apps for best performance."
+                        .into(),
+                )
+            } else {
+                Some(
+                    "With 8 GB RAM the 4B LLM is the safest choice — \
+                     it leaves room for ASR and OS."
+                        .into(),
+                )
             };
             (
-                asr,
+                ModelPick {
+                    model_id: "asr-large-v3-turbo-q5".into(),
+                    reason: asr_reason,
+                    confidence: "high".into(),
+                },
                 Some(ModelPick {
-                    model_id: "llm-qwen3-8b".into(),
-                    reason: "Fits comfortably alongside ASR in 16 GB".into(),
+                    model_id: "llm-qwen3-4b".into(),
+                    reason: llm_reason,
                     confidence: "high".into(),
                 }),
-                None,
+                warn,
             )
         }
-        _ => (
-            ModelPick {
-                model_id: "asr-large-v3-turbo".into(),
-                reason: "Best quality model — plenty of RAM available".into(),
-                confidence: "high".into(),
-            },
-            Some(ModelPick {
-                model_id: "llm-qwen3-14b".into(),
-                reason: "Largest available model fits well with 24+ GB RAM".into(),
-                confidence: "high".into(),
-            }),
-            None,
-        ),
+
+        // ── 10-15 GB (e.g. 12 GB MacBook Air M2, 12-15 GB Windows laptop) ───
+        10..=15 => {
+            if is_apple_silicon {
+                // Full turbo is fine (1.7 GB); 4B LLM (3 GB) + ASR (1.7 GB) + OS (4 GB)
+                // = ~9 GB → comfortable. Recommending 8B here risks pressure (5.5 + 1.7 + 4 = 11.2).
+                (
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo".into(),
+                        reason: "Full-precision turbo runs via Metal on Apple Silicon".into(),
+                        confidence: "high".into(),
+                    },
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-4b".into(),
+                        reason:
+                            "3 GB runtime footprint is safe alongside ASR on 12 GB unified memory"
+                                .into(),
+                        confidence: "high".into(),
+                    }),
+                    None,
+                )
+            } else {
+                // x86 12-15 GB: use Q5 ASR (faster on CPU-only inference)
+                (
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo-q5".into(),
+                        reason: "Quantized turbo is faster on CPU inference and uses only ~620 MB"
+                            .into(),
+                        confidence: "high".into(),
+                    },
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-4b".into(),
+                        reason: "2.5 GB on disk — safe alongside ASR with OS overhead on 12 GB"
+                            .into(),
+                        confidence: "high".into(),
+                    }),
+                    if memory_pressure {
+                        Some(
+                            "System memory appears to be under pressure. \
+                             Close other apps before recording."
+                                .into(),
+                        )
+                    } else {
+                        None
+                    },
+                )
+            }
+        }
+
+        // ── 16-23 GB (e.g. M1 Pro/M2 Pro 16 GB, typical 16 GB laptop) ──────
+        16..=23 => {
+            if is_apple_silicon {
+                // M1 Pro/M2 Pro 16 GB: Metal working set ~10.7 GB.
+                // ASR turbo (1.7 GB) + 8B LLM (5.5 GB) + OS (5 GB) ≈ 12 GB → comfortable.
+                // 14B LLM (9.5 GB) + ASR (1.7 GB) + OS (5 GB) ≈ 16 GB → too tight.
+                let asr_reason = if metal_gb > 0 {
+                    format!(
+                        "Full-precision turbo — Metal can use up to {metal_gb} GB of your \
+                         unified memory pool"
+                    )
+                } else {
+                    "Full-precision turbo runs via Metal on Apple Silicon 16 GB".into()
+                };
+                (
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo".into(),
+                        reason: asr_reason,
+                        confidence: "high".into(),
+                    },
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-8b".into(),
+                        reason:
+                            "~5.5 GB runtime fits comfortably alongside ASR in 16 GB unified memory"
+                                .into(),
+                        confidence: "high".into(),
+                    }),
+                    None,
+                )
+            } else {
+                // x86 16 GB: no Metal acceleration, CPU inference is the bottleneck.
+                // Full turbo on CPU is slow; Q5 is a better UX default.
+                // Exception: high core count (≥12) makes full turbo viable.
+                let asr = if hw.cpu_cores >= 12 {
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo".into(),
+                        reason: "High core count offsets CPU-only inference — full turbo is viable"
+                            .into(),
+                        confidence: "medium".into(),
+                    }
+                } else {
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo-q5".into(),
+                        reason:
+                            "Quantized turbo is faster on CPU-only inference with similar accuracy"
+                                .into(),
+                        confidence: "high".into(),
+                    }
+                };
+                (
+                    asr,
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-8b".into(),
+                        reason: "Fits comfortably alongside ASR on 16 GB RAM".into(),
+                        confidence: "high".into(),
+                    }),
+                    if memory_pressure {
+                        Some(
+                            "System memory is under pressure. \
+                             Consider closing other applications before recording."
+                                .into(),
+                        )
+                    } else {
+                        None
+                    },
+                )
+            }
+        }
+
+        // ── 24+ GB (e.g. M1 Max/M2 Max/M3 Pro 24-96 GB, 32 GB workstation) ─
+        _ => {
+            if is_apple_silicon {
+                // ASR turbo (1.7 GB) + 14B LLM (9.5 GB) + OS (5 GB) ≈ 16 GB → fits in 24+ GB.
+                let llm_reason = if metal_gb >= 16 {
+                    format!(
+                        "14B model (~9.5 GB runtime) fits well — Metal working set is \
+                         {metal_gb} GB on your device"
+                    )
+                } else {
+                    "14B model (~9.5 GB runtime) fits alongside ASR with room to spare on 24+ GB"
+                        .into()
+                };
+                (
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo".into(),
+                        reason:
+                            "Best accuracy — large unified memory pool enables fast Metal inference"
+                                .into(),
+                        confidence: "high".into(),
+                    },
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-14b".into(),
+                        reason: llm_reason,
+                        confidence: "high".into(),
+                    }),
+                    None,
+                )
+            } else {
+                // High-end Windows/Linux workstation with dedicated GPU or lots of RAM.
+                (
+                    ModelPick {
+                        model_id: "asr-large-v3-turbo".into(),
+                        reason: "Best quality model — plenty of RAM available".into(),
+                        confidence: "high".into(),
+                    },
+                    Some(ModelPick {
+                        model_id: "llm-qwen3-14b".into(),
+                        reason: "Largest available model fits well with 24+ GB RAM".into(),
+                        confidence: "high".into(),
+                    }),
+                    None,
+                )
+            }
+        }
     }
 }

--- a/src-tauri/src/commands/streaming.rs
+++ b/src-tauri/src/commands/streaming.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 use crate::ipc_error::{ErrorCode, IpcError};
 
-use echo_app::StreamingPipeline;
+use echo_app::{NaivePunctuator, StreamingPipeline};
 use echo_domain::{
     AudioFormat, AudioSource, CaptureSpec, StreamingOptions, StreamingSessionId, TranscriptEvent,
     Vad,
@@ -157,6 +157,7 @@ pub async fn start_streaming(
     } else {
         tracing::info!("neural VAD disabled by request; using RMS gate");
     }
+    pipeline = pipeline.with_punctuator(Arc::new(NaivePunctuator));
 
     let handle = pipeline
         .start_with_spec(spec, streaming_options)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,15 @@ pub fn run() {
                     let _ = w.hide();
                 }
             }
+            // macOS: dock icon clicked while all windows are hidden.
+            // Without this handler the app stays invisible even though
+            // it is still running, making the dock click feel broken.
+            tauri::RunEvent::Reopen {
+                has_visible_windows,
+                ..
+            } if !has_visible_windows => {
+                show_main_window(app_handle);
+            }
             tauri::RunEvent::Exit => {
                 // Ordered shutdown: drain streaming sessions, close SQLite.
                 let state = app_handle.state::<commands::AppState>();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -196,6 +196,9 @@ pub fn run() {
             // macOS: dock icon clicked while all windows are hidden.
             // Without this handler the app stays invisible even though
             // it is still running, making the dock click feel broken.
+            // RunEvent::Reopen is a macOS-only variant; the cfg guard
+            // prevents a compile error on Windows and Linux.
+            #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen {
                 has_visible_windows,
                 ..

--- a/src/features/live/LivePane.tsx
+++ b/src/features/live/LivePane.tsx
@@ -1,7 +1,7 @@
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { PanelLeft, Mic } from "lucide-react";
+import { PanelLeft, Mic, Pause, Play } from "lucide-react";
 
 import { LogoAnimated } from "../../components/Logo";
 import { ResizableHandleVertical } from "../../components/ResizableHandleVertical";
@@ -396,8 +396,9 @@ export function LivePane({
             <button
               type="button"
               onClick={onPause}
-              className="rounded-full bg-amber-600/10 px-3 py-1.5 text-ui-sm font-medium text-amber-700 ring-1 ring-amber-500/30 transition-colors hover:bg-amber-600/20 dark:text-amber-400"
+              className="relative z-10 flex items-center gap-1.5 rounded-full bg-amber-600/10 px-3 py-1.5 text-ui-sm font-medium text-amber-700 ring-1 ring-amber-500/30 transition-colors hover:bg-amber-600/20 dark:text-amber-400"
             >
+              <Pause className="h-3.5 w-3.5" />
               {t("live.pause")}
             </button>
           )}
@@ -405,8 +406,9 @@ export function LivePane({
             <button
               type="button"
               onClick={onResume}
-              className="rounded-full bg-emerald-600/10 px-3 py-1.5 text-ui-sm font-medium text-emerald-700 ring-1 ring-emerald-500/30 transition-colors hover:bg-emerald-600/20 dark:text-emerald-400"
+              className="relative z-10 flex items-center gap-1.5 rounded-full bg-emerald-600 px-5 py-1.5 text-ui-sm font-medium text-white shadow-sm transition-colors hover:bg-emerald-500"
             >
+              <Play className="h-3.5 w-3.5 fill-white" />
               {t("live.resume")}
             </button>
           )}
@@ -416,9 +418,9 @@ export function LivePane({
               onClick={onStop}
               className="relative flex items-center gap-2 rounded-full bg-rose-600 px-5 py-1.5 text-ui-sm font-medium text-white shadow-sm transition-colors hover:bg-rose-500"
             >
-              {/* Active ring radiating while recording */}
+              {/* Active ring radiating while recording — pointer-events-none so it never intercepts clicks on adjacent buttons */}
               {stream.kind === "recording" && (
-                <span className="absolute inset-0 rounded-full border-2 border-rose-400 animate-rec-ring" />
+                <span className="pointer-events-none absolute inset-0 rounded-full border-2 border-rose-400 animate-rec-ring" />
               )}
               <span className="relative inline-flex h-2.5 w-2.5 rounded-sm bg-white/90" />
               <span className="relative">{stream.kind === "stopping" ? t("live.stopping") : t("live.stop")}</span>
@@ -426,8 +428,14 @@ export function LivePane({
           )}
         </div>
 
-        {/* Right: timer echo */}
+        {/* Right: timer + paused badge */}
         <div className="flex items-center gap-2">
+          {canResume && (
+            <span className="flex items-center gap-1 rounded-full bg-amber-500/15 px-2.5 py-1 text-micro font-semibold text-amber-600 ring-1 ring-amber-500/30 animate-pulse dark:text-amber-400">
+              <Pause className="h-2.5 w-2.5 fill-current" />
+              {t("live.paused")}
+            </span>
+          )}
           {isActive && (
             <span className="font-mono text-ui-xs tabular-nums text-content-tertiary">
               {formatTimer(stats.audioMs)}


### PR DESCRIPTION
## Summary

- **ASR quality improvements** — three filters to reduce Whisper hallucinations and noise:
  - Post-hoc `no_speech_probability > 0.6` filter (works around `set_no_speech_thold` being unimplemented in whisper.cpp)
  - Greedy repetition-loop detector: drops segments where any 1–3-gram repeats 4+ times consecutively
  - `NaivePunctuator`: rule-based punctuation restoration (capitalises first char, adds `.`/`?`) wired as a `Punctuator` port in `echo-domain` and activated by default in every streaming session

- **Hardware-aware model recommendations** — finer tiers for Apple Silicon:
  - Splits the old 10–19 GB bucket into 10–15 GB (4B LLM) / 16–23 GB (8B LLM) / 24+ GB (14B LLM)
  - Detects Apple Silicon via `cpu_brand` "Apple M" + `unified_memory` (not just core count)
  - Uses Metal working set (`gpu_max_working_set`) in reason text
  - Adds available-RAM pressure warning for non-unified platforms

- **macOS dock icon fix** — handle `tauri::RunEvent::Reopen` so clicking the dock icon after hide-to-tray restores the window

## Test plan

- [ ] `cargo test -p echo-app -p echo-asr` passes
- [ ] Start a streaming session — transcript segments have capital first letter and terminal punctuation
- [ ] Record silence — no phantom segments appear
- [ ] Open Models panel → Hardware step shows correct recommendation for the device
- [ ] Close window with ⌘W, click dock icon — window reopens