### PR TITLE
fix(i18n): replace hardcoded strings with translation keys across UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         shared-key: macos-14
 
     - name: Setup pnpm (version from packageManager field)
-      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -169,7 +169,7 @@ jobs:
         shared-key: ubuntu-24.04
 
     - name: Setup pnpm (version from packageManager field)
-      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
@@ -213,7 +213,7 @@ jobs:
         cargo audit
 
     - name: Setup pnpm (version from packageManager field)
-      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
 
     # --- Frontend ---
     - name: Setup pnpm
-      uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+      uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
 
     - name: Setup Node
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -782,16 +782,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -813,20 +803,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
+ "core-foundation",
+ "core-graphics-types",
  "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -837,7 +816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "libc",
 ]
 
@@ -2563,7 +2542,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3340,13 +3319,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.30.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3572083504c43e14aec05447f8a3d57cce0f66d7a3c1b9058572eca4d70ab9"
+checksum = "c7047791b5bc903b8cd963014b355f71dc9864a9a0b727057676c1dcae5cbc15"
 dependencies = [
  "bitflags 2.11.1",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types",
  "foreign-types",
  "log",
  "objc",
@@ -4966,7 +4945,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -5117,7 +5096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5913,7 +5892,7 @@ checksum = "1cf65722394c2ac443e80120064987f8914ee1d4e4e36e63cdf10f2990f01159"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-graphics",
  "crossbeam-channel",
  "dbus",
@@ -7525,7 +7504,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,7 +2563,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -6106,9 +6106,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -6124,9 +6124,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
@@ -6142,7 +6142,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -6173,9 +6173,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-single-instance"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
 dependencies = [
  "serde",
  "serde_json",
@@ -6488,9 +6488,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7525,7 +7525,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "echo-app"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1396,7 +1396,7 @@ dependencies = [
 
 [[package]]
 name = "echo-asr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "echo-audio",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "echo-audio"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "cpal",
@@ -1432,7 +1432,7 @@ dependencies = [
 
 [[package]]
 name = "echo-diarize"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "echo-domain"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "echo-llm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1481,7 +1481,7 @@ dependencies = [
 
 [[package]]
 name = "echo-mcp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "echo-app",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "echo-proto"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "echo-shell"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dirs",
  "echo-app",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "echo-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "echo-domain",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "echo-telemetry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 # Shared package metadata inherited by member crates via `package.xxx.workspace = true`
 # -----------------------------------------------------------------------------
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Luis MC <luismctechdev@gmail.com>"]

--- a/crates/echo-app/src/use_cases/streaming/mod.rs
+++ b/crates/echo-app/src/use_cases/streaming/mod.rs
@@ -149,6 +149,27 @@ impl StreamingPipeline {
         spec: CaptureSpec,
         options: StreamingOptions,
     ) -> Result<StreamingHandle, StreamingError> {
+        self.start_inner(PipelineSource::Spec(spec), options).await
+    }
+
+    /// Start transcription with an already-started audio stream. Use this
+    /// when the caller needs to start the capture itself (e.g. to retain
+    /// [`MixControls`] for a `Mixed` session) and then hand the stream off
+    /// to the pipeline.
+    pub async fn start_with_stream(
+        self,
+        stream: Box<dyn echo_domain::AudioStream>,
+        options: StreamingOptions,
+    ) -> Result<StreamingHandle, StreamingError> {
+        self.start_inner(PipelineSource::Prestarted(stream), options)
+            .await
+    }
+
+    async fn start_inner(
+        self,
+        source: PipelineSource,
+        options: StreamingOptions,
+    ) -> Result<StreamingHandle, StreamingError> {
         let session_id = StreamingSessionId::new();
         let (event_tx, event_rx) = mpsc::channel::<TranscriptEvent>(EVENT_CHANNEL_CAPACITY);
         let (stop_tx, stop_rx) = oneshot::channel::<()>();
@@ -185,7 +206,7 @@ impl StreamingPipeline {
             self.vad,
             self.punctuator,
             session_id,
-            spec,
+            source,
             options,
             event_tx,
             stop_rx,
@@ -200,6 +221,14 @@ impl StreamingPipeline {
             paused,
         })
     }
+}
+
+/// Describes how a pipeline session obtains its audio stream.
+enum PipelineSource {
+    /// Derive the stream by calling `capture.start(spec)` inside the pipeline task.
+    Spec(CaptureSpec),
+    /// Use a stream that was already started by the caller.
+    Prestarted(Box<dyn echo_domain::AudioStream>),
 }
 
 /// Whisper's canonical sample rate. Inlined here to avoid pulling
@@ -290,7 +319,7 @@ async fn run_pipeline(
     mut vad: Option<Box<dyn Vad>>,
     punctuator: Option<Arc<dyn Punctuator>>,
     session_id: StreamingSessionId,
-    spec: CaptureSpec,
+    source: PipelineSource,
     options: StreamingOptions,
     events: mpsc::Sender<TranscriptEvent>,
     mut stop_rx: oneshot::Receiver<()>,
@@ -304,18 +333,21 @@ async fn run_pipeline(
         v.reset();
     }
 
-    let mut stream = match capture.start(spec).await {
-        Ok(s) => s,
-        Err(e) => {
-            error!(error = %e, "capture.start failed");
-            let _ = events
-                .send(TranscriptEvent::Failed {
-                    session_id,
-                    message: format!("capture failed to start: {e}"),
-                })
-                .await;
-            return;
-        }
+    let mut stream = match source {
+        PipelineSource::Spec(spec) => match capture.start(spec).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!(error = %e, "capture.start failed");
+                let _ = events
+                    .send(TranscriptEvent::Failed {
+                        session_id,
+                        message: format!("capture failed to start: {e}"),
+                    })
+                    .await;
+                return;
+            }
+        },
+        PipelineSource::Prestarted(s) => s,
     };
 
     let format = stream.format();

--- a/crates/echo-audio/src/capture/mixed.rs
+++ b/crates/echo-audio/src/capture/mixed.rs
@@ -1,10 +1,13 @@
 //! Mixed-source audio capture: mic + system audio merged into one stream.
 //!
 //! `MixedStream` reads concurrently from a microphone stream and a system
-//! audio (loopback) stream, accumulates samples in two independent ring
-//! buffers, and emits mixed frames whenever either buffer reaches the
-//! threshold. Mixing is a per-sample average with a simple zero-pad when
-//! one source is behind the other.
+//! audio (loopback) stream, normalizes each source to a common target
+//! format (channel downmix + sample-rate conversion), and emits mixed
+//! frames whenever either per-source buffer reaches the threshold.
+//! Mixing is a per-sample average over the *normalized* samples, so
+//! sources delivering different native rates or channel counts (e.g.
+//! built-in mic mono 48 kHz vs ScreenCaptureKit stereo 48 kHz) line up
+//! correctly in the time domain.
 //!
 //! Each source can be independently muted at any time by storing `false`
 //! in the corresponding `Arc<AtomicBool>` returned alongside the stream.
@@ -15,19 +18,25 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use rubato::{Resampler as RubatoResampler, SincFixedIn};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use echo_domain::{AudioFormat, AudioFrame, AudioStream, DomainError, Sample};
 
-/// Interleaved-sample threshold before a mixed frame is emitted.
-/// ~10 ms at 48 kHz stereo (1024 interleaved samples = 512 stereo frames).
-const MIX_THRESHOLD: usize = 1024;
+use crate::preprocess::resample::{
+    downmix_to_mono, make_sinc_resampler, ResampleError, RESAMPLE_CHUNK_SIZE,
+};
 
-/// Maximum per-source buffer depth before old samples are dropped.
-/// ~340 ms at 48 kHz stereo — protects against pathological clock drift.
-const MAX_DRIFT_SAMPLES: usize = MIX_THRESHOLD * 16;
+/// Samples per emitted mixed frame. ~10 ms at 16 kHz mono.
+/// Picked to match the cadence of upstream capture frames.
+const MIX_THRESHOLD: usize = 160;
+
+/// Maximum per-source buffer depth before old normalized samples are
+/// dropped. ~340 ms at 16 kHz mono — protects against pathological clock
+/// drift between mic and system streams.
+const MAX_DRIFT_SAMPLES: usize = MIX_THRESHOLD * 32;
 
 /// Channel depth in mixed frames. ~5 s of headroom at 10 ms/frame.
 const CHANNEL_CAPACITY: usize = 512;
@@ -72,14 +81,46 @@ impl MixedStream {
     ///
     /// Both `mic_stream` and `sys_stream` **must** be live capture streams
     /// (calling `next_frame()` should not immediately return `None`).
-    /// `format` is the declared output format — both sources are treated as
-    /// if they deliver samples at this rate/channel count, so callers should
-    /// ensure both were started with a matching `preferred_format`.
+    ///
+    /// `target_format` is the format the mixer will emit. Each source is
+    /// downmixed to mono (`channels = 1`) and resampled from its native
+    /// rate to `target_format.sample_rate_hz`. The target format is
+    /// typically [`AudioFormat::WHISPER`] (16 kHz mono) so downstream
+    /// resampling is a no-op.
+    ///
+    /// Returns an error if a per-source resampler cannot be built (e.g.
+    /// when the source format has zero sample rate). When that happens
+    /// neither stream is started — callers can fall back to single-source
+    /// capture.
     pub fn new(
         mic_stream: Box<dyn AudioStream>,
         sys_stream: Box<dyn AudioStream>,
-        format: AudioFormat,
-    ) -> (Self, MixControls) {
+        target_format: AudioFormat,
+    ) -> Result<(Self, MixControls), DomainError> {
+        let mic_format = mic_stream.format();
+        let sys_format = sys_stream.format();
+
+        // Build the per-source normalizers up front so we surface any
+        // resampler-construction error synchronously instead of panicking
+        // inside the spawned task.
+        let mic_norm = SourceNormalizer::new(mic_format, target_format).map_err(|e| {
+            DomainError::AudioCaptureFailed(format!(
+                "mic normalizer ({mic_format:?} -> {target_format:?}): {e}"
+            ))
+        })?;
+        let sys_norm = SourceNormalizer::new(sys_format, target_format).map_err(|e| {
+            DomainError::AudioCaptureFailed(format!(
+                "sys normalizer ({sys_format:?} -> {target_format:?}): {e}"
+            ))
+        })?;
+
+        debug!(
+            target = ?target_format,
+            mic = ?mic_format,
+            sys = ?sys_format,
+            "mixed-stream: starting with per-source normalization"
+        );
+
         let controls = MixControls::default();
         let (tx, rx) = mpsc::channel::<AudioFrame>(CHANNEL_CAPACITY);
         let (stop_tx, stop_rx) = oneshot::channel::<()>();
@@ -88,17 +129,25 @@ impl MixedStream {
         let sys_active = controls.sys_active.clone();
 
         let join = tokio::spawn(run_mixer(
-            mic_stream, sys_stream, format, tx, stop_rx, mic_active, sys_active,
+            mic_stream,
+            sys_stream,
+            mic_norm,
+            sys_norm,
+            target_format,
+            tx,
+            stop_rx,
+            mic_active,
+            sys_active,
         ));
 
         let stream = Self {
             rx,
             stop_tx: Some(stop_tx),
             join: Some(join),
-            format,
+            format: target_format,
         };
 
-        (stream, controls)
+        Ok((stream, controls))
     }
 }
 
@@ -136,13 +185,90 @@ impl Drop for MixedStream {
 }
 
 // ---------------------------------------------------------------------------
+// Per-source normalizer
+// ---------------------------------------------------------------------------
+
+/// Converts a single source's native samples into target-format mono
+/// samples. Owns a `SincFixedIn` resampler when the rates differ;
+/// otherwise the downmixed mono samples pass through.
+///
+/// The resampler runs in fixed input-chunks of `RESAMPLE_CHUNK_SIZE`
+/// frames; the normalizer pre-buffers incoming samples until a full chunk
+/// is available, then emits the resampled output.
+struct SourceNormalizer {
+    #[allow(dead_code)]
+    native: AudioFormat,
+    #[allow(dead_code)]
+    target: AudioFormat,
+    resampler: Option<SincFixedIn<Sample>>,
+    /// Pre-buffer of mono samples in the *native* rate awaiting a full
+    /// chunk before being pushed through `rubato`.
+    pending: Vec<Sample>,
+}
+
+impl SourceNormalizer {
+    fn new(native: AudioFormat, target: AudioFormat) -> Result<Self, ResampleError> {
+        if target.channels != 1 {
+            return Err(ResampleError::InvalidFormat(target));
+        }
+        let resampler = if native.sample_rate_hz != target.sample_rate_hz {
+            Some(make_sinc_resampler(
+                native.sample_rate_hz,
+                target.sample_rate_hz,
+            )?)
+        } else {
+            None
+        };
+        Ok(Self {
+            native,
+            target,
+            resampler,
+            pending: Vec::with_capacity(RESAMPLE_CHUNK_SIZE * 2),
+        })
+    }
+
+    /// Push native-format samples; append target-format mono samples to `out`.
+    fn push(&mut self, samples: &[Sample], out: &mut Vec<Sample>) {
+        if samples.is_empty() {
+            return;
+        }
+        // 1. Downmix to mono if the source is multi-channel.
+        let mono: Vec<Sample> = if self.native.channels > 1 {
+            downmix_to_mono(samples, self.native.channels)
+        } else {
+            samples.to_vec()
+        };
+        // 2. Same rate? Pass mono through directly.
+        let Some(rs) = self.resampler.as_mut() else {
+            out.extend_from_slice(&mono);
+            return;
+        };
+        // 3. Different rate: buffer + chunked rubato.
+        self.pending.extend_from_slice(&mono);
+        while self.pending.len() >= RESAMPLE_CHUNK_SIZE {
+            // Drain a chunk into a contiguous buffer for rubato.
+            let chunk: Vec<Sample> = self.pending.drain(..RESAMPLE_CHUNK_SIZE).collect();
+            match rs.process(&[chunk.as_slice()], None) {
+                Ok(frames) => out.extend_from_slice(&frames[0]),
+                Err(e) => {
+                    warn!(error = %e, "mixed-stream: resampler error; dropping chunk");
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Mixer task
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 async fn run_mixer(
     mut mic: Box<dyn AudioStream>,
     mut sys: Box<dyn AudioStream>,
-    format: AudioFormat,
+    mut mic_norm: SourceNormalizer,
+    mut sys_norm: SourceNormalizer,
+    target_format: AudioFormat,
     tx: mpsc::Sender<AudioFrame>,
     mut stop_rx: oneshot::Receiver<()>,
     mic_active: Arc<AtomicBool>,
@@ -154,9 +280,9 @@ async fn run_mixer(
     let mut sys_buf: Vec<Sample> = Vec::with_capacity(MIX_THRESHOLD * 4);
     let mut elapsed_ns: u64 = 0;
 
-    // Nanoseconds per interleaved sample at the declared output rate.
-    let ns_per_sample = if format.sample_rate_hz > 0 && format.channels > 0 {
-        1_000_000_000u64 / (format.sample_rate_hz as u64 * format.channels as u64)
+    // Nanoseconds per (mono) sample at the declared target rate.
+    let ns_per_sample = if target_format.sample_rate_hz > 0 {
+        1_000_000_000u64 / u64::from(target_format.sample_rate_hz)
     } else {
         0
     };
@@ -170,20 +296,12 @@ async fn run_mixer(
 
             let mut mixed = Vec::with_capacity(n);
             for i in 0..n {
-                let mic_s = if use_mic && i < mic_buf.len() {
-                    mic_buf[i]
-                } else {
-                    0.0_f32
-                };
-                let sys_s = if use_sys && i < sys_buf.len() {
-                    sys_buf[i]
-                } else {
-                    0.0_f32
-                };
-                let sample = match (use_mic && i < mic_buf.len(), use_sys && i < sys_buf.len()) {
-                    (true, true) => (mic_s + sys_s) * 0.5,
-                    (true, false) => mic_s,
-                    (false, true) => sys_s,
+                let mic_avail = use_mic && i < mic_buf.len();
+                let sys_avail = use_sys && i < sys_buf.len();
+                let sample = match (mic_avail, sys_avail) {
+                    (true, true) => (mic_buf[i] + sys_buf[i]) * 0.5,
+                    (true, false) => mic_buf[i],
+                    (false, true) => sys_buf[i],
                     (false, false) => 0.0_f32,
                 };
                 mixed.push(sample.clamp(-1.0, 1.0));
@@ -196,7 +314,7 @@ async fn run_mixer(
 
             let frame = AudioFrame {
                 samples: mixed,
-                format,
+                format: target_format,
                 captured_at_ns: elapsed_ns,
             };
             elapsed_ns = elapsed_ns.saturating_add(ns_per_sample * n as u64);
@@ -215,7 +333,7 @@ async fn run_mixer(
             }
             frame = mic.next_frame() => {
                 match frame {
-                    Some(f) => mic_buf.extend_from_slice(&f.samples),
+                    Some(f) => mic_norm.push(&f.samples, &mut mic_buf),
                     None => {
                         debug!("mixed-stream: mic stream ended");
                         break;
@@ -224,7 +342,7 @@ async fn run_mixer(
             }
             frame = sys.next_frame() => {
                 match frame {
-                    Some(f) => sys_buf.extend_from_slice(&f.samples),
+                    Some(f) => sys_norm.push(&f.samples, &mut sys_buf),
                     None => {
                         debug!("mixed-stream: system stream ended");
                         break;
@@ -252,5 +370,190 @@ async fn run_mixer(
         }
     }
 
+    drop(mic_norm);
+    drop(sys_norm);
     debug!("mixed-stream mixer stopped");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::time::Duration;
+    use tokio::sync::Mutex as AsyncMutex;
+
+    /// Test stream that yields a queue of pre-built frames then ends.
+    struct ScriptedStream {
+        format: AudioFormat,
+        frames: AsyncMutex<std::collections::VecDeque<AudioFrame>>,
+    }
+
+    impl ScriptedStream {
+        fn boxed(format: AudioFormat, frames: Vec<AudioFrame>) -> Box<dyn AudioStream> {
+            Box::new(Self {
+                format,
+                frames: AsyncMutex::new(frames.into()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl AudioStream for ScriptedStream {
+        fn format(&self) -> AudioFormat {
+            self.format
+        }
+        async fn next_frame(&mut self) -> Option<AudioFrame> {
+            let mut q = self.frames.lock().await;
+            if let Some(f) = q.pop_front() {
+                Some(f)
+            } else {
+                // Block forever — emulates a live stream that hasn't ended.
+                drop(q);
+                std::future::pending::<()>().await;
+                None
+            }
+        }
+        async fn stop(&mut self) -> Result<(), DomainError> {
+            Ok(())
+        }
+    }
+
+    fn sine(samples: usize, freq_hz: f32, rate_hz: u32, channels: u16) -> Vec<f32> {
+        let mut v = Vec::with_capacity(samples);
+        let frames = samples / channels as usize;
+        let two_pi_f_over_sr = 2.0 * std::f32::consts::PI * freq_hz / rate_hz as f32;
+        for i in 0..frames {
+            let s = (two_pi_f_over_sr * i as f32).sin() * 0.5;
+            for _ in 0..channels {
+                v.push(s);
+            }
+        }
+        v
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        if samples.is_empty() {
+            return 0.0;
+        }
+        let sum: f32 = samples.iter().map(|s| s * s).sum();
+        (sum / samples.len() as f32).sqrt()
+    }
+
+    /// Reproduces the original bug: mic at mono 48 kHz, sys at stereo
+    /// 48 kHz, mixer normalizes both to 16 kHz mono so neither source
+    /// dominates the other.
+    #[tokio::test]
+    async fn mismatched_native_formats_normalize_to_target() {
+        let mic_format = AudioFormat {
+            sample_rate_hz: 48_000,
+            channels: 1,
+        };
+        let sys_format = AudioFormat {
+            sample_rate_hz: 48_000,
+            channels: 2,
+        };
+
+        // 100 ms of audio in each native format.
+        let mic_frame = AudioFrame {
+            samples: sine(4_800, 440.0, 48_000, 1),
+            format: mic_format,
+            captured_at_ns: 0,
+        };
+        let sys_frame = AudioFrame {
+            samples: sine(9_600, 880.0, 48_000, 2),
+            format: sys_format,
+            captured_at_ns: 0,
+        };
+
+        let mic = ScriptedStream::boxed(mic_format, vec![mic_frame]);
+        let sys = ScriptedStream::boxed(sys_format, vec![sys_frame]);
+
+        let (mut stream, _ctrl) =
+            MixedStream::new(mic, sys, AudioFormat::WHISPER).expect("build mixed stream");
+
+        assert_eq!(stream.format(), AudioFormat::WHISPER);
+
+        // Drain a few frames and check they have meaningful RMS — proves
+        // the mic contribution survives even when the sys stream pushes
+        // twice as many native samples per millisecond.
+        let mut received = Vec::new();
+        for _ in 0..4 {
+            let next = tokio::time::timeout(Duration::from_millis(200), stream.next_frame()).await;
+            if let Ok(Some(f)) = next {
+                received.extend_from_slice(&f.samples);
+            }
+        }
+
+        assert!(
+            !received.is_empty(),
+            "mixer must produce frames from mismatched-format sources"
+        );
+        let r = rms(&received);
+        assert!(
+            r > 0.05,
+            "expected non-trivial mixed RMS, got {r} — mic likely lost in the mix"
+        );
+    }
+
+    /// When the system source is muted via `MixControls`, the output must
+    /// still contain mic samples at full energy (no halving from the
+    /// `(mic+sys)*0.5` average).
+    #[tokio::test]
+    async fn muted_sys_passes_mic_through_unattenuated() {
+        let mic_format = AudioFormat {
+            sample_rate_hz: 48_000,
+            channels: 1,
+        };
+        let sys_format = AudioFormat {
+            sample_rate_hz: 48_000,
+            channels: 2,
+        };
+
+        let mic_frame = AudioFrame {
+            samples: sine(4_800, 440.0, 48_000, 1),
+            format: mic_format,
+            captured_at_ns: 0,
+        };
+        let sys_frame = AudioFrame {
+            samples: vec![0.0; 9_600],
+            format: sys_format,
+            captured_at_ns: 0,
+        };
+
+        let mic = ScriptedStream::boxed(mic_format, vec![mic_frame]);
+        let sys = ScriptedStream::boxed(sys_format, vec![sys_frame]);
+
+        let (mut stream, ctrl) =
+            MixedStream::new(mic, sys, AudioFormat::WHISPER).expect("build mixed stream");
+
+        // Mute sys before any frames are produced.
+        ctrl.sys_active.store(false, Ordering::Relaxed);
+
+        let mut received = Vec::new();
+        for _ in 0..4 {
+            let next = tokio::time::timeout(Duration::from_millis(200), stream.next_frame()).await;
+            if let Ok(Some(f)) = next {
+                received.extend_from_slice(&f.samples);
+            }
+        }
+
+        assert!(
+            !received.is_empty(),
+            "mixer must keep producing with sys muted"
+        );
+        let r = rms(&received);
+        // A 440 Hz sine at amplitude 0.5 has RMS ≈ 0.354. Resampling
+        // and chunk-edge effects can pull it down slightly, but it must
+        // stay well above the "half" floor that the old per-index mixer
+        // produced (which would land around 0.17 because it averaged
+        // mic with zeroed sys).
+        assert!(
+            r > 0.2,
+            "mic-only RMS {r} suggests the muted sys is still attenuating the mix"
+        );
+    }
 }

--- a/crates/echo-audio/src/capture/mixed.rs
+++ b/crates/echo-audio/src/capture/mixed.rs
@@ -1,0 +1,256 @@
+//! Mixed-source audio capture: mic + system audio merged into one stream.
+//!
+//! `MixedStream` reads concurrently from a microphone stream and a system
+//! audio (loopback) stream, accumulates samples in two independent ring
+//! buffers, and emits mixed frames whenever either buffer reaches the
+//! threshold. Mixing is a per-sample average with a simple zero-pad when
+//! one source is behind the other.
+//!
+//! Each source can be independently muted at any time by storing `false`
+//! in the corresponding `Arc<AtomicBool>` returned alongside the stream.
+//! When a source is muted its samples are zeroed in the mix; the underlying
+//! capture keeps running so no audio is dropped on unmute.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+use echo_domain::{AudioFormat, AudioFrame, AudioStream, DomainError, Sample};
+
+/// Interleaved-sample threshold before a mixed frame is emitted.
+/// ~10 ms at 48 kHz stereo (1024 interleaved samples = 512 stereo frames).
+const MIX_THRESHOLD: usize = 1024;
+
+/// Maximum per-source buffer depth before old samples are dropped.
+/// ~340 ms at 48 kHz stereo — protects against pathological clock drift.
+const MAX_DRIFT_SAMPLES: usize = MIX_THRESHOLD * 16;
+
+/// Channel depth in mixed frames. ~5 s of headroom at 10 ms/frame.
+const CHANNEL_CAPACITY: usize = 512;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Atomic flags that independently gate each source's contribution to the mix.
+///
+/// Both flags start as `true` (both sources contribute). Setting a flag to
+/// `false` zeros out that source's samples; setting it back to `true`
+/// restores contribution immediately on the next emitted frame.
+#[derive(Clone)]
+pub struct MixControls {
+    /// When `true` the microphone samples are included in the mix.
+    pub mic_active: Arc<AtomicBool>,
+    /// When `true` the system-audio samples are included in the mix.
+    pub sys_active: Arc<AtomicBool>,
+}
+
+impl Default for MixControls {
+    fn default() -> Self {
+        Self {
+            mic_active: Arc::new(AtomicBool::new(true)),
+            sys_active: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+/// An [`AudioStream`] that merges a microphone stream and a system-audio
+/// stream into a single output. Construct via [`MixedStream::new`].
+pub struct MixedStream {
+    rx: mpsc::Receiver<AudioFrame>,
+    stop_tx: Option<oneshot::Sender<()>>,
+    join: Option<JoinHandle<()>>,
+    format: AudioFormat,
+}
+
+impl MixedStream {
+    /// Spawn the mixer task and return the stream + its control handles.
+    ///
+    /// Both `mic_stream` and `sys_stream` **must** be live capture streams
+    /// (calling `next_frame()` should not immediately return `None`).
+    /// `format` is the declared output format — both sources are treated as
+    /// if they deliver samples at this rate/channel count, so callers should
+    /// ensure both were started with a matching `preferred_format`.
+    pub fn new(
+        mic_stream: Box<dyn AudioStream>,
+        sys_stream: Box<dyn AudioStream>,
+        format: AudioFormat,
+    ) -> (Self, MixControls) {
+        let controls = MixControls::default();
+        let (tx, rx) = mpsc::channel::<AudioFrame>(CHANNEL_CAPACITY);
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+
+        let mic_active = controls.mic_active.clone();
+        let sys_active = controls.sys_active.clone();
+
+        let join = tokio::spawn(run_mixer(
+            mic_stream, sys_stream, format, tx, stop_rx, mic_active, sys_active,
+        ));
+
+        let stream = Self {
+            rx,
+            stop_tx: Some(stop_tx),
+            join: Some(join),
+            format,
+        };
+
+        (stream, controls)
+    }
+}
+
+#[async_trait]
+impl AudioStream for MixedStream {
+    fn format(&self) -> AudioFormat {
+        self.format
+    }
+
+    async fn next_frame(&mut self) -> Option<AudioFrame> {
+        self.rx.recv().await
+    }
+
+    async fn stop(&mut self) -> Result<(), DomainError> {
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+        self.rx.close();
+        Ok(())
+    }
+}
+
+impl Drop for MixedStream {
+    fn drop(&mut self) {
+        if let Some(tx) = self.stop_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(join) = self.join.take() {
+            join.abort();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mixer task
+// ---------------------------------------------------------------------------
+
+async fn run_mixer(
+    mut mic: Box<dyn AudioStream>,
+    mut sys: Box<dyn AudioStream>,
+    format: AudioFormat,
+    tx: mpsc::Sender<AudioFrame>,
+    mut stop_rx: oneshot::Receiver<()>,
+    mic_active: Arc<AtomicBool>,
+    sys_active: Arc<AtomicBool>,
+) {
+    debug!("mixed-stream mixer started");
+
+    let mut mic_buf: Vec<Sample> = Vec::with_capacity(MIX_THRESHOLD * 4);
+    let mut sys_buf: Vec<Sample> = Vec::with_capacity(MIX_THRESHOLD * 4);
+    let mut elapsed_ns: u64 = 0;
+
+    // Nanoseconds per interleaved sample at the declared output rate.
+    let ns_per_sample = if format.sample_rate_hz > 0 && format.channels > 0 {
+        1_000_000_000u64 / (format.sample_rate_hz as u64 * format.channels as u64)
+    } else {
+        0
+    };
+
+    loop {
+        // Drain both buffers into mixed frames before waiting for more input.
+        while mic_buf.len() >= MIX_THRESHOLD || sys_buf.len() >= MIX_THRESHOLD {
+            let n = MIX_THRESHOLD;
+            let use_mic = mic_active.load(Ordering::Relaxed);
+            let use_sys = sys_active.load(Ordering::Relaxed);
+
+            let mut mixed = Vec::with_capacity(n);
+            for i in 0..n {
+                let mic_s = if use_mic && i < mic_buf.len() {
+                    mic_buf[i]
+                } else {
+                    0.0_f32
+                };
+                let sys_s = if use_sys && i < sys_buf.len() {
+                    sys_buf[i]
+                } else {
+                    0.0_f32
+                };
+                let sample = match (use_mic && i < mic_buf.len(), use_sys && i < sys_buf.len()) {
+                    (true, true) => (mic_s + sys_s) * 0.5,
+                    (true, false) => mic_s,
+                    (false, true) => sys_s,
+                    (false, false) => 0.0_f32,
+                };
+                mixed.push(sample.clamp(-1.0, 1.0));
+            }
+
+            let consumed_mic = n.min(mic_buf.len());
+            let consumed_sys = n.min(sys_buf.len());
+            mic_buf.drain(..consumed_mic);
+            sys_buf.drain(..consumed_sys);
+
+            let frame = AudioFrame {
+                samples: mixed,
+                format,
+                captured_at_ns: elapsed_ns,
+            };
+            elapsed_ns = elapsed_ns.saturating_add(ns_per_sample * n as u64);
+
+            if tx.send(frame).await.is_err() {
+                debug!("mixed-stream: consumer dropped, stopping mixer");
+                return;
+            }
+        }
+
+        // Wait for new samples from either source.
+        tokio::select! {
+            _ = &mut stop_rx => {
+                debug!("mixed-stream: stop signal received");
+                break;
+            }
+            frame = mic.next_frame() => {
+                match frame {
+                    Some(f) => mic_buf.extend_from_slice(&f.samples),
+                    None => {
+                        debug!("mixed-stream: mic stream ended");
+                        break;
+                    }
+                }
+            }
+            frame = sys.next_frame() => {
+                match frame {
+                    Some(f) => sys_buf.extend_from_slice(&f.samples),
+                    None => {
+                        debug!("mixed-stream: system stream ended");
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Trim buffers that have drifted too far ahead.
+        if mic_buf.len() > MAX_DRIFT_SAMPLES {
+            let excess = mic_buf.len() - MAX_DRIFT_SAMPLES;
+            warn!(
+                excess,
+                "mixed-stream: mic buffer drifted; dropping old samples"
+            );
+            mic_buf.drain(..excess);
+        }
+        if sys_buf.len() > MAX_DRIFT_SAMPLES {
+            let excess = sys_buf.len() - MAX_DRIFT_SAMPLES;
+            warn!(
+                excess,
+                "mixed-stream: sys buffer drifted; dropping old samples"
+            );
+            sys_buf.drain(..excess);
+        }
+    }
+
+    debug!("mixed-stream mixer stopped");
+}

--- a/crates/echo-audio/src/capture/mod.rs
+++ b/crates/echo-audio/src/capture/mod.rs
@@ -9,9 +9,11 @@
 //! - **Linux**: [`linux::PulseMonitorCapture`] via PulseAudio monitor sources.
 
 pub mod cpal_microphone;
+pub mod mixed;
 pub mod routing;
 
 pub use cpal_microphone::CpalMicrophoneCapture;
+pub use mixed::{MixControls, MixedStream};
 pub use routing::RoutingAudioCapture;
 
 #[cfg(target_os = "macos")]

--- a/crates/echo-audio/src/capture/routing.rs
+++ b/crates/echo-audio/src/capture/routing.rs
@@ -130,6 +130,13 @@ impl RoutingAudioCapture {
     /// into a single [`MixedStream`]. Returns the stream and a
     /// [`MixControls`] handle that can mute each source independently
     /// during the live session.
+    ///
+    /// The mixer normalizes each source independently (channel downmix +
+    /// sample-rate conversion) to [`AudioFormat::WHISPER`] (16 kHz mono)
+    /// before combining them. This makes the mix correct even when the
+    /// mic and system streams negotiate different native formats — the
+    /// common case on macOS, where built-in mics expose mono 48 kHz while
+    /// ScreenCaptureKit delivers stereo 48 kHz.
     pub async fn start_mixed(
         &self,
         spec: CaptureSpec,
@@ -142,10 +149,12 @@ impl RoutingAudioCapture {
             )
         })?;
 
-        // Both sources are requested at 48 kHz stereo — the native rate of
-        // ScreenCaptureKit and most macOS CoreAudio configurations. The
-        // downstream pipeline resampler converts this to 16 kHz mono for Whisper.
-        let stereo_48k = AudioFormat {
+        // Each source is started at its native preferred rate (48 kHz
+        // stereo is a reasonable hint for both cpal and ScreenCaptureKit;
+        // adapters fall back to whatever the device actually supports).
+        // The MixedStream then downmixes + resamples each stream to the
+        // canonical Whisper target so the per-sample mix is time-aligned.
+        let hint = AudioFormat {
             sample_rate_hz: 48_000,
             channels: 2,
         };
@@ -153,18 +162,18 @@ impl RoutingAudioCapture {
         let mic_spec = CaptureSpec {
             source: AudioSource::Microphone,
             device_id: spec.device_id.clone(),
-            preferred_format: stereo_48k,
+            preferred_format: hint,
         };
         let sys_spec = CaptureSpec {
             source: AudioSource::SystemOutput,
             device_id: None,
-            preferred_format: stereo_48k,
+            preferred_format: hint,
         };
 
         let mic_stream = self.microphone.start(mic_spec).await?;
         let sys_stream = sys_adapter.clone().start(sys_spec).await?;
 
-        let (stream, controls) = MixedStream::new(mic_stream, sys_stream, stereo_48k);
+        let (stream, controls) = MixedStream::new(mic_stream, sys_stream, AudioFormat::WHISPER)?;
         Ok((Box::new(stream), controls))
     }
 }

--- a/crates/echo-audio/src/capture/routing.rs
+++ b/crates/echo-audio/src/capture/routing.rs
@@ -14,22 +14,23 @@
 //! │                       │  SystemOutput      ┌─────────────────────┐
 //! │                       ├──────────────────▶│ ScreenCaptureKit-   │
 //! │                       │                   │ Capture (macOS)     │
-//! └───────────────────────┘                   └─────────────────────┘
+//! │                       │  Mixed             └─────────────────────┘
+//! │                       ├──────────────────▶ Both adapters → MixedStream
+//! └───────────────────────┘
 //! ```
 //!
 //! On unsupported targets the system-output slot is `None` and any
-//! request for `AudioSource::SystemOutput` returns
-//! [`DomainError::AudioDeviceUnavailable`] with a clear message.
-//!
-//! The composite is intentionally *only* a router. Mixing two streams
-//! into a single [`AudioStream`] (mic + system in the same session)
-//! lands in a follow-up issue once the diarizer is wired and we know
-//! how the downstream API wants to label each speaker track.
+//! request for `AudioSource::SystemOutput` or `AudioSource::Mixed`
+//! returns [`DomainError::AudioDeviceUnavailable`] with a clear message.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use echo_domain::{AudioCapture, AudioSource, AudioStream, CaptureSpec, DeviceInfo, DomainError};
+use echo_domain::{
+    AudioCapture, AudioFormat, AudioSource, AudioStream, CaptureSpec, DeviceInfo, DomainError,
+};
+
+use super::mixed::{MixControls, MixedStream};
 
 use crate::CpalMicrophoneCapture;
 
@@ -115,12 +116,56 @@ impl RoutingAudioCapture {
     fn pick(&self, source: AudioSource) -> Result<&Arc<dyn AudioCapture>, DomainError> {
         match source {
             AudioSource::Microphone => Ok(&self.microphone),
-            AudioSource::SystemOutput => self.system_output.as_ref().ok_or_else(|| {
-                DomainError::AudioDeviceUnavailable(
-                    "system audio capture is not available on this platform".into(),
-                )
-            }),
+            AudioSource::SystemOutput | AudioSource::Mixed => {
+                self.system_output.as_ref().ok_or_else(|| {
+                    DomainError::AudioDeviceUnavailable(
+                        "system audio capture is not available on this platform".into(),
+                    )
+                })
+            }
         }
+    }
+
+    /// Start both the microphone and system-audio streams and merge them
+    /// into a single [`MixedStream`]. Returns the stream and a
+    /// [`MixControls`] handle that can mute each source independently
+    /// during the live session.
+    pub async fn start_mixed(
+        &self,
+        spec: CaptureSpec,
+    ) -> Result<(Box<dyn AudioStream>, MixControls), DomainError> {
+        let sys_adapter = self.system_output.as_ref().ok_or_else(|| {
+            DomainError::AudioDeviceUnavailable(
+                "system audio capture is not available on this platform; \
+                 Mixed mode requires both microphone and system-audio support"
+                    .into(),
+            )
+        })?;
+
+        // Both sources are requested at 48 kHz stereo — the native rate of
+        // ScreenCaptureKit and most macOS CoreAudio configurations. The
+        // downstream pipeline resampler converts this to 16 kHz mono for Whisper.
+        let stereo_48k = AudioFormat {
+            sample_rate_hz: 48_000,
+            channels: 2,
+        };
+
+        let mic_spec = CaptureSpec {
+            source: AudioSource::Microphone,
+            device_id: spec.device_id.clone(),
+            preferred_format: stereo_48k,
+        };
+        let sys_spec = CaptureSpec {
+            source: AudioSource::SystemOutput,
+            device_id: None,
+            preferred_format: stereo_48k,
+        };
+
+        let mic_stream = self.microphone.start(mic_spec).await?;
+        let sys_stream = sys_adapter.clone().start(sys_spec).await?;
+
+        let (stream, controls) = MixedStream::new(mic_stream, sys_stream, stereo_48k);
+        Ok((Box::new(stream), controls))
     }
 }
 
@@ -133,10 +178,24 @@ impl Default for RoutingAudioCapture {
 #[async_trait]
 impl AudioCapture for RoutingAudioCapture {
     async fn list_devices(&self, source: AudioSource) -> Result<Vec<DeviceInfo>, DomainError> {
+        if source == AudioSource::Mixed {
+            // Synthesise a single logical "mixed" device.
+            return Ok(vec![DeviceInfo {
+                id: "mixed:default".to_string(),
+                name: "Mixed (Microphone + System Audio)".to_string(),
+                is_default: true,
+            }]);
+        }
         self.pick(source)?.list_devices(source).await
     }
 
     async fn start(&self, spec: CaptureSpec) -> Result<Box<dyn AudioStream>, DomainError> {
+        if spec.source == AudioSource::Mixed {
+            // Discard mix controls — callers that need live-toggle must use
+            // `start_mixed` directly so they can retain the control handles.
+            let (stream, _controls) = self.start_mixed(spec).await?;
+            return Ok(stream);
+        }
         let adapter = self.pick(spec.source)?.clone();
         adapter.start(spec).await
     }

--- a/crates/echo-audio/src/lib.rs
+++ b/crates/echo-audio/src/lib.rs
@@ -21,13 +21,15 @@
 
 pub mod buffer;
 pub mod capture;
+pub mod output_device;
 pub mod preprocess;
 pub mod sink;
 
 pub use buffer::SamplePool;
-pub use capture::{CpalMicrophoneCapture, RoutingAudioCapture};
+pub use capture::{CpalMicrophoneCapture, MixControls, MixedStream, RoutingAudioCapture};
 #[cfg(target_os = "macos")]
 pub use capture::{ScreenCaptureKitCapture, SYSTEM_OUTPUT_DEVICE_ID};
+pub use output_device::{default_output_device_info, OutputDeviceInfo};
 pub use preprocess::resample::{
     resample_to_whisper, ResampleError, RubatoResamplerAdapter, WHISPER_SAMPLE_RATE,
 };

--- a/crates/echo-audio/src/output_device.rs
+++ b/crates/echo-audio/src/output_device.rs
@@ -1,0 +1,47 @@
+//! Default audio output device detection.
+//!
+//! Used by the UI to suggest Mixed mode when headphones are detected.
+
+use cpal::traits::{DeviceTrait, HostTrait};
+
+/// Information about the system's current default audio output device.
+#[derive(Debug, Clone)]
+pub struct OutputDeviceInfo {
+    /// Human-readable name reported by the OS.
+    pub name: String,
+    /// Heuristic: `true` when the name suggests headphones / earbuds
+    /// rather than built-in or external speakers.
+    pub is_headphones: bool,
+}
+
+/// Query the default output device using cpal. Returns `None` when the host
+/// has no output device or the device name cannot be read.
+///
+/// This call may briefly access the CoreAudio / WASAPI subsystem; run it
+/// on a blocking thread if latency matters.
+pub fn default_output_device_info() -> Option<OutputDeviceInfo> {
+    let device = cpal::default_host().default_output_device()?;
+    let name = device.description().ok()?.name().to_string();
+    let is_headphones = looks_like_headphones(&name);
+    Some(OutputDeviceInfo {
+        name,
+        is_headphones,
+    })
+}
+
+fn looks_like_headphones(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    lower.contains("airpod")
+        || lower.contains("headphone")
+        || lower.contains("headset")
+        || lower.contains("earphone")
+        || lower.contains("earpod")
+        || lower.contains("earbuds")
+        || lower.contains("jabra")
+        || lower.contains("plantronics")
+        || lower.contains("bose")
+        || lower.contains("sennheiser")
+        || lower.contains("sony wh")
+        || lower.contains("sony wf")
+        || lower.contains("beats")
+}

--- a/crates/echo-audio/src/preprocess/resample.rs
+++ b/crates/echo-audio/src/preprocess/resample.rs
@@ -75,7 +75,7 @@ pub fn resample_to_whisper(
 /// Equal-weight downmix. Stereo -> mean(L, R); 5.1 -> mean of all six
 /// channels. Good enough for ASR; high-fidelity downmix lands later if
 /// the LLM benchmark demands it.
-fn downmix_to_mono(samples: &[Sample], channels: u16) -> Vec<Sample> {
+pub(crate) fn downmix_to_mono(samples: &[Sample], channels: u16) -> Vec<Sample> {
     if channels <= 1 {
         return samples.to_vec();
     }
@@ -95,10 +95,13 @@ fn downmix_to_mono(samples: &[Sample], channels: u16) -> Vec<Sample> {
 }
 
 /// Internal chunk size for rubato processing (input frames per call).
-const RESAMPLE_CHUNK_SIZE: usize = 1024;
+pub(crate) const RESAMPLE_CHUNK_SIZE: usize = 1024;
 
 /// Build a fresh [`SincFixedIn`] resampler for the given rate pair.
-fn make_sinc_resampler(from_hz: u32, to_hz: u32) -> Result<SincFixedIn<f32>, ResampleError> {
+pub(crate) fn make_sinc_resampler(
+    from_hz: u32,
+    to_hz: u32,
+) -> Result<SincFixedIn<f32>, ResampleError> {
     let params = SincInterpolationParameters {
         sinc_len: 256,
         f_cutoff: 0.95,

--- a/crates/echo-domain/src/ports/audio.rs
+++ b/crates/echo-domain/src/ports/audio.rs
@@ -46,6 +46,12 @@ pub enum AudioSource {
     /// permissions: ScreenCaptureKit on macOS, WASAPI loopback on
     /// Windows, PulseAudio monitor on Linux.
     SystemOutput,
+    /// Microphone + system audio merged into one stream. On macOS both
+    /// cpal (mic) and ScreenCaptureKit (system) run concurrently; their
+    /// samples are averaged before reaching the transcription pipeline.
+    /// Ideal for video calls with headphones: mic captures the local
+    /// speaker, system captures the remote participants.
+    Mixed,
 }
 
 /// Sample-rate / channel configuration of a stream.

--- a/crates/echo-proto/src/main.rs
+++ b/crates/echo-proto/src/main.rs
@@ -620,9 +620,9 @@ async fn run_stream(
     // by named device. Surfacing `--device` for it would be misleading.
     let device_id = match source {
         AudioSource::Microphone => device,
-        AudioSource::SystemOutput => {
+        AudioSource::SystemOutput | AudioSource::Mixed => {
             if device.is_some() {
-                tracing::warn!("--device is ignored when --source system-output");
+                tracing::warn!("--device is ignored when --source system-output/mixed");
             }
             None
         }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@tanstack/react-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.11.0",
-    "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/cli": "^2.11.0",
-    "@types/node": "^25.6.0",
+    "@types/node": "^25.6.2",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.1",
@@ -45,8 +45,8 @@
     "postcss": "^8.5.14",
     "tailwindcss": "^3.4.15",
     "typescript": "^6.0.3",
-    "vite": "^8.0.10",
-    "vitest": "^4.1.5"
+    "vite": "^8.0.12",
+    "vitest": "^4.1.6"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-dom": "^18.3.1",
     "react-i18next": "^17.0.4",
     "react-markdown": "^10.1.0",
-    "rehype-sanitize": "^6.0.0"
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "echonote",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Private, local-first meeting transcription and AI summaries.",
   "type": "module",
   "packageManager": "pnpm@10.13.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lucide-react": "^1.14.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-i18next": "^17.0.4",
+    "react-i18next": "^17.0.7",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
     devDependencies:
       '@tailwindcss/typography':
         specifier: ^0.5.19
@@ -573,6 +576,10 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   estree-util-is-identifier-name@3.0.0:
     resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
@@ -790,8 +797,32 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -820,6 +851,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -1040,11 +1092,17 @@ packages:
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -1682,6 +1740,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@3.0.3:
@@ -1873,6 +1933,15 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -1887,6 +1956,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1981,6 +2107,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-factory-destination@2.0.1:
@@ -2244,6 +2428,17 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -2260,6 +2455,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve@1.22.12:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.11.0
         version: 2.11.0
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.7.0
-        version: 2.7.0
+        specifier: ^2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-global-shortcut':
         specifier: ^2.3.1
         version: 2.3.1
@@ -64,8 +64,8 @@ importers:
         specifier: ^2.11.0
         version: 2.11.1
       '@types/node':
-        specifier: ^25.6.0
-        version: 25.6.0
+        specifier: ^25.6.2
+        version: 25.7.0
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.28
@@ -74,7 +74,7 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7))
+        version: 6.0.1(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.14)
@@ -88,11 +88,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.10
-        version: 8.0.10(@types/node@25.6.0)(jiti@1.21.7)
+        specifier: ^8.0.12
+        version: 8.0.12(@types/node@25.7.0)(jiti@1.21.7)
       vitest:
-        specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7))
+        specifier: ^4.1.6
+        version: 4.1.6(@types/node@25.7.0)(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7))
 
 packages:
 
@@ -150,100 +150,100 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@oxc-project/types@0.127.0':
-    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+  '@oxc-project/types@0.129.0':
+    resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+  '@rolldown/binding-android-arm64@1.0.0':
+    resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+  '@rolldown/binding-darwin-arm64@1.0.0':
+    resolution: {integrity: sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+  '@rolldown/binding-darwin-x64@1.0.0':
+    resolution: {integrity: sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+  '@rolldown/binding-freebsd-x64@1.0.0':
+    resolution: {integrity: sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
+    resolution: {integrity: sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
+    resolution: {integrity: sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
+    resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
+    resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
+    resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
+    resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+  '@rolldown/binding-linux-x64-musl@1.0.0':
+    resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0':
+    resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0':
+    resolution: {integrity: sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
+    resolution: {integrity: sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
+    resolution: {integrity: sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.17':
-    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+  '@rolldown/pluginutils@1.0.0':
+    resolution: {integrity: sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==}
 
   '@rolldown/pluginutils@1.0.0-rc.7':
     resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
@@ -339,8 +339,8 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-dialog@2.7.0':
-    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
   '@tauri-apps/plugin-global-shortcut@2.3.1':
     resolution: {integrity: sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g==}
@@ -378,8 +378,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@25.7.0':
+    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -414,11 +414,11 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
-  '@vitest/expect@4.1.5':
-    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+  '@vitest/expect@4.1.6':
+    resolution: {integrity: sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==}
 
-  '@vitest/mocker@4.1.5':
-    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+  '@vitest/mocker@4.1.6':
+    resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -428,20 +428,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.5':
-    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+  '@vitest/pretty-format@4.1.6':
+    resolution: {integrity: sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==}
 
-  '@vitest/runner@4.1.5':
-    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+  '@vitest/runner@4.1.6':
+    resolution: {integrity: sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==}
 
-  '@vitest/snapshot@4.1.5':
-    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+  '@vitest/snapshot@4.1.6':
+    resolution: {integrity: sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==}
 
-  '@vitest/spy@4.1.5':
-    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+  '@vitest/spy@4.1.6':
+    resolution: {integrity: sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==}
 
-  '@vitest/utils@4.1.5':
-    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+  '@vitest/utils@4.1.6':
+    resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1113,8 +1113,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown@1.0.0-rc.17:
-    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+  rolldown@1.0.0:
+    resolution: {integrity: sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -1206,8 +1206,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.21.0:
+    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -1247,13 +1247,13 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@8.0.10:
-    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+  vite@8.0.12:
+    resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.1.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1290,20 +1290,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.5:
-    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+  vitest@4.1.6:
+    resolution: {integrity: sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.5
-      '@vitest/browser-preview': 4.1.5
-      '@vitest/browser-webdriverio': 4.1.5
-      '@vitest/coverage-istanbul': 4.1.5
-      '@vitest/coverage-v8': 4.1.5
-      '@vitest/ui': 4.1.5
+      '@vitest/browser-playwright': 4.1.6
+      '@vitest/browser-preview': 4.1.6
+      '@vitest/browser-webdriverio': 4.1.6
+      '@vitest/coverage-istanbul': 4.1.6
+      '@vitest/coverage-v8': 4.1.6
+      '@vitest/ui': 4.1.6
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -1402,58 +1402,58 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@oxc-project/types@0.127.0': {}
+  '@oxc-project/types@0.129.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+  '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+  '@rolldown/binding-darwin-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+  '@rolldown/binding-freebsd-x64@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-arm64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-gnu@1.0.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+  '@rolldown/binding-linux-x64-musl@1.0.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+  '@rolldown/binding-openharmony-arm64@1.0.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+  '@rolldown/binding-wasm32-wasi@1.0.0':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+  '@rolldown/binding-win32-x64-msvc@1.0.0':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.17': {}
+  '@rolldown/pluginutils@1.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
 
@@ -1521,7 +1521,7 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
 
-  '@tauri-apps/plugin-dialog@2.7.0':
+  '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 
@@ -1569,9 +1569,9 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@25.6.0':
+  '@types/node@25.7.0':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.21.0
 
   '@types/prop-types@15.7.15': {}
 
@@ -1590,49 +1590,49 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.10(@types/node@25.6.0)(jiti@1.21.7)
+      vite: 8.0.12(@types/node@25.7.0)(jiti@1.21.7)
 
-  '@vitest/expect@4.1.5':
+  '@vitest/expect@4.1.6':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7))':
+  '@vitest/mocker@4.1.6(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7))':
     dependencies:
-      '@vitest/spy': 4.1.5
+      '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(jiti@1.21.7)
+      vite: 8.0.12(@types/node@25.7.0)(jiti@1.21.7)
 
-  '@vitest/pretty-format@4.1.5':
+  '@vitest/pretty-format@4.1.6':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.5':
+  '@vitest/runner@4.1.6':
     dependencies:
-      '@vitest/utils': 4.1.5
+      '@vitest/utils': 4.1.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.5':
+  '@vitest/snapshot@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/utils': 4.1.6
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.5': {}
+  '@vitest/spy@4.1.6': {}
 
-  '@vitest/utils@4.1.5':
+  '@vitest/utils@4.1.6':
     dependencies:
-      '@vitest/pretty-format': 4.1.5
+      '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -2471,26 +2471,26 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown@1.0.0-rc.17:
+  rolldown@1.0.0:
     dependencies:
-      '@oxc-project/types': 0.127.0
-      '@rolldown/pluginutils': 1.0.0-rc.17
+      '@oxc-project/types': 0.129.0
+      '@rolldown/pluginutils': 1.0.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-android-arm64': 1.0.0
+      '@rolldown/binding-darwin-arm64': 1.0.0
+      '@rolldown/binding-darwin-x64': 1.0.0
+      '@rolldown/binding-freebsd-x64': 1.0.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0
+      '@rolldown/binding-linux-arm64-musl': 1.0.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-gnu': 1.0.0
+      '@rolldown/binding-linux-x64-musl': 1.0.0
+      '@rolldown/binding-openharmony-arm64': 1.0.0
+      '@rolldown/binding-wasm32-wasi': 1.0.0
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0
+      '@rolldown/binding-win32-x64-msvc': 1.0.0
 
   run-parallel@1.2.0:
     dependencies:
@@ -2597,7 +2597,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.21.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -2654,27 +2654,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7):
+  vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.14
-      rolldown: 1.0.0-rc.17
+      rolldown: 1.0.0
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.7.0
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7)):
+  vitest@4.1.6(@types/node@25.7.0)(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7)):
     dependencies:
-      '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@1.21.7))
-      '@vitest/pretty-format': 4.1.5
-      '@vitest/runner': 4.1.5
-      '@vitest/snapshot': 4.1.5
-      '@vitest/spy': 4.1.5
-      '@vitest/utils': 4.1.5
+      '@vitest/expect': 4.1.6
+      '@vitest/mocker': 4.1.6(vite@8.0.12(@types/node@25.7.0)(jiti@1.21.7))
+      '@vitest/pretty-format': 4.1.6
+      '@vitest/runner': 4.1.6
+      '@vitest/snapshot': 4.1.6
+      '@vitest/spy': 4.1.6
+      '@vitest/utils': 4.1.6
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -2686,10 +2686,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(jiti@1.21.7)
+      vite: 8.0.12(@types/node@25.7.0)(jiti@1.21.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 25.7.0
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-i18next:
-        specifier: ^17.0.4
-        version: 17.0.4(i18next@26.0.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
+        specifier: ^17.0.7
+        version: 17.0.7(i18next@26.0.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
@@ -1056,10 +1056,10 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-i18next@17.0.4:
-    resolution: {integrity: sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==}
+  react-i18next@17.0.7:
+    resolution: {integrity: sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==}
     peerDependencies:
-      i18next: '>= 26.0.1'
+      i18next: '>= 26.0.10'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
@@ -2382,7 +2382,7 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
-  react-i18next@17.0.4(i18next@26.0.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
+  react-i18next@17.0.7(i18next@26.0.10(typescript@6.0.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ keepawake = "0.6"
 sha2 = "0.11"
 scopeguard = "1"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
-tauri-plugin-dialog = "2.7.0"
+tauri-plugin-dialog = "2.7.1"
 tauri-plugin-global-shortcut = "2.3.1"
 specta.workspace = true
 specta-typescript.workspace = true

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,7 +70,7 @@ tauri-specta.workspace = true
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-metal = "0.30"
+metal = "0.33"
 
 [features]
 # Default features are left empty; the shell opts in to platform backends

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -42,9 +42,7 @@ use echo_diarize::{
     embedding::SpeakerEmbedder, CamPlusPlusEmbedder, Eres2NetEmbedder, OnlineDiarizer,
     PyannoteSegmenter,
 };
-use echo_domain::{
-    AudioCapture, ChatAssistant, Diarizer, LlmModel, MeetingStore, Resampler, Transcriber,
-};
+use echo_domain::{ChatAssistant, Diarizer, LlmModel, MeetingStore, Resampler, Transcriber};
 use echo_llm::{LlamaCppLlm, LoadOptions as LlamaLoadOptions};
 use echo_storage::SqliteMeetingStore;
 
@@ -136,7 +134,7 @@ pub fn health_check() -> HealthStatus {
 /// SQLite-backed meeting store, the per-session meeting recorder and
 /// the in-flight streaming sessions so they can be stopped from the UI.
 pub struct AppState {
-    pub(crate) capture: Arc<dyn AudioCapture>,
+    pub(crate) capture: Arc<RoutingAudioCapture>,
     pub(crate) resampler: Arc<dyn Resampler>,
     /// Shared HTTP client with connect timeout. Reused across all model
     /// downloads to amortise TLS handshake and connection-pool overhead.
@@ -193,6 +191,11 @@ pub(crate) struct SessionEntry {
     /// RAII guard — prevents the OS from sleeping while recording.
     /// Dropped automatically when the session entry is removed.
     pub _keep_awake: Option<keepawake::KeepAwake>,
+    /// Mix source controls — `Some` only when the session was started
+    /// with `AudioSource::Mixed`. The `set_mix_sources` command
+    /// writes to these flags to toggle each source during a live session.
+    pub mic_active: Option<Arc<std::sync::atomic::AtomicBool>>,
+    pub sys_active: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl AppState {

--- a/src-tauri/src/commands/streaming.rs
+++ b/src-tauri/src/commands/streaming.rs
@@ -12,6 +12,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use crate::ipc_error::{ErrorCode, IpcError};
 
 use echo_app::{NaivePunctuator, StreamingPipeline};
+use echo_audio::MixControls;
 use echo_domain::{
     AudioFormat, AudioSource, CaptureSpec, StreamingOptions, StreamingSessionId, TranscriptEvent,
     Vad,
@@ -29,6 +30,9 @@ pub enum IpcAudioSource {
     Microphone,
     /// System audio loopback (macOS 13+ via ScreenCaptureKit).
     SystemOutput,
+    /// Microphone + system audio merged. Both sources run concurrently;
+    /// each can be muted/unmuted live via `set_mix_sources`.
+    Mixed,
 }
 
 impl From<IpcAudioSource> for AudioSource {
@@ -36,8 +40,63 @@ impl From<IpcAudioSource> for AudioSource {
         match value {
             IpcAudioSource::Microphone => AudioSource::Microphone,
             IpcAudioSource::SystemOutput => AudioSource::SystemOutput,
+            IpcAudioSource::Mixed => AudioSource::Mixed,
         }
     }
+}
+
+/// Information about the current system audio output device.
+#[derive(Debug, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OutputDeviceInfo {
+    /// Human-readable name of the default output device.
+    pub name: String,
+    /// Heuristic: `true` when the device name suggests headphones /
+    /// earbuds / in-ear monitors rather than built-in or external speakers.
+    pub is_headphones: bool,
+}
+
+/// Return the name and headphone-heuristic for the default output device.
+#[tauri::command]
+#[specta::specta]
+pub async fn get_output_device_info() -> Result<Option<OutputDeviceInfo>, IpcError> {
+    let info = tokio::task::spawn_blocking(echo_audio::default_output_device_info)
+        .await
+        .unwrap_or(None);
+
+    Ok(info.map(|i| OutputDeviceInfo {
+        name: i.name,
+        is_headphones: i.is_headphones,
+    }))
+}
+
+/// Toggle which sources contribute to the mix for an active `Mixed` session.
+/// Returns `false` when the session is not found or was not started in Mixed mode.
+#[tauri::command]
+#[specta::specta]
+pub async fn set_mix_sources(
+    state: State<'_, AppState>,
+    session_id: StreamingSessionId,
+    mic_active: bool,
+    sys_active: bool,
+) -> Result<bool, IpcError> {
+    let map = state.sessions.lock().map_err(|e| {
+        IpcError::new(
+            ErrorCode::SessionConflict,
+            format!("session map poisoned: {e}"),
+        )
+    })?;
+    let Some(entry) = map.get(&session_id) else {
+        return Ok(false);
+    };
+    let has_controls = entry.mic_active.is_some() || entry.sys_active.is_some();
+    if let Some(flag) = &entry.mic_active {
+        flag.store(mic_active, std::sync::atomic::Ordering::Release);
+    }
+    if let Some(flag) = &entry.sys_active {
+        flag.store(sys_active, std::sync::atomic::Ordering::Release);
+    }
+    Ok(has_controls)
 }
 
 /// Options the frontend may pass when starting a streaming session.
@@ -124,10 +183,10 @@ pub async fn start_streaming(
     // a named device; surface a warning if the frontend forgets.
     let device_id = match source {
         AudioSource::Microphone => opts.device_id,
-        AudioSource::SystemOutput => {
+        AudioSource::SystemOutput | AudioSource::Mixed => {
             if opts.device_id.is_some() {
                 tracing::warn!(
-                    "deviceId ignored when source = systemOutput \
+                    "deviceId ignored when source = systemOutput/mixed \
                      (ScreenCaptureKit selects the primary display)"
                 );
             }
@@ -141,8 +200,11 @@ pub async fn start_streaming(
     };
 
     let transcriber = state.ensure_transcriber().await?;
-    let mut pipeline =
-        StreamingPipeline::new(state.capture.clone(), state.resampler.clone(), transcriber);
+    let mut pipeline = StreamingPipeline::new(
+        state.capture.clone() as Arc<dyn echo_domain::AudioCapture>,
+        state.resampler.clone(),
+        transcriber,
+    );
     if opts.diarize.unwrap_or(false) {
         let diarizer = state.build_diarizer(opts.embed_model_path)?;
         pipeline = pipeline.with_diarizer(diarizer);
@@ -159,10 +221,31 @@ pub async fn start_streaming(
     }
     pipeline = pipeline.with_punctuator(Arc::new(NaivePunctuator));
 
-    let handle = pipeline
-        .start_with_spec(spec, streaming_options)
-        .await
-        .map_err(|e| IpcError::new(ErrorCode::Audio, format!("failed to start streaming: {e}")))?;
+    // For Mixed source: start both captures directly so we can retain the
+    // MixControls handles for live source toggling via set_mix_sources.
+    let (handle, mix_controls) = if source == AudioSource::Mixed {
+        let (stream, controls) = state.capture.start_mixed(spec).await.map_err(|e| {
+            IpcError::new(
+                ErrorCode::Audio,
+                format!("failed to start mixed capture: {e}"),
+            )
+        })?;
+        let handle = pipeline
+            .start_with_stream(stream, streaming_options)
+            .await
+            .map_err(|e| {
+                IpcError::new(ErrorCode::Audio, format!("failed to start streaming: {e}"))
+            })?;
+        (handle, Some(controls))
+    } else {
+        let handle = pipeline
+            .start_with_spec(spec, streaming_options)
+            .await
+            .map_err(|e| {
+                IpcError::new(ErrorCode::Audio, format!("failed to start streaming: {e}"))
+            })?;
+        (handle, None)
+    };
     let session_id = handle.session_id();
     let paused_flag = handle.paused_flag();
 
@@ -227,6 +310,10 @@ pub async fn start_streaming(
             format!("session map poisoned: {e}"),
         )
     });
+    let (mic_active, sys_active) = mix_controls
+        .map(|c: MixControls| (Some(c.mic_active), Some(c.sys_active)))
+        .unwrap_or((None, None));
+
     insert_result?.insert(
         session_id,
         SessionEntry {
@@ -241,6 +328,8 @@ pub async fn start_streaming(
                 .create()
                 .map_err(|e| tracing::warn!("keep-awake unavailable: {e}"))
                 .ok(),
+            mic_active,
+            sys_active,
         },
     );
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,8 @@ pub fn run() {
             commands::streaming::pause_streaming,
             commands::streaming::resume_streaming,
             commands::streaming::get_meeting_id,
+            commands::streaming::get_output_device_info,
+            commands::streaming::set_mix_sources,
             commands::meetings::list_meetings,
             commands::meetings::get_meeting,
             commands::meetings::delete_meeting,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "EchoNote",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "identifier": "app.echonote.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,17 +229,22 @@ export function App() {
 
   return (
     <main className="flex h-full w-full flex-col gap-3 overflow-hidden px-4 py-3 sm:px-6 sm:py-4">
-      <header className="flex flex-shrink-0 items-end justify-between gap-4">
-        <div className="flex items-center gap-2.5">
-          <LogoMark size={28} className="flex-shrink-0" />
-          <div className="flex flex-col">
-            <h1 className="text-[22px] font-semibold leading-tight tracking-tight">
-              {t("app.title")}
-            </h1>
-            <p className="hidden text-ui-sm text-content-tertiary sm:block">
-              {t("app.subtitle")}
-            </p>
-          </div>
+      <header className="flex flex-shrink-0 items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <LogoMark size={32} className="flex-shrink-0 drop-shadow-[0_0_12px_rgba(59,232,165,0.25)]" />
+          <h1 className="text-[28px] font-semibold leading-none tracking-[-0.02em] text-content-primary">
+            {t("app.title")}
+          </h1>
+          <span
+            className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50/60 px-2 py-0.5 text-micro font-medium text-emerald-700 ring-1 ring-emerald-200/60 dark:bg-emerald-900/20 dark:text-emerald-400 dark:ring-emerald-800/40"
+            title={t("app.subtitle")}
+          >
+            <span
+              className="h-1.5 w-1.5 rounded-full bg-emerald-500 shadow-[0_0_0_2px_rgba(16,185,129,0.18)]"
+              aria-hidden
+            />
+            {t("app.privacyChip")}
+          </span>
         </div>
         <div className="flex items-center gap-2">
           <ThemeSwitcher />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,11 @@
  * for the same reason.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LayoutGrid } from "lucide-react";
 
+import { getOutputDeviceInfo } from "./ipc/client";
 import { LogoMark } from "./components/Logo";
 import { useToast } from "./components/Toaster";
 import { OnboardingFlow } from "./features/onboarding/OnboardingFlow";
@@ -98,24 +99,51 @@ export function App() {
     start: startRecording,
     reset: resetRecording,
     stop: stopRecording,
+    setMixSources: recordingSetMixSources,
   } = recording;
 
   // Diarize is opt-in to keep the existing whisper-only path unchanged
   // for users who haven't downloaded the embedder yet.
   const [diarize, setDiarize] = useState(false);
   const [language, setLanguage] = useState<string>("es");
+  const [audioSource, setAudioSource] = useState<import("./types/streaming").AudioSourceKind>("microphone");
+  const [micActive, setMicActive] = useState(true);
+  const [sysActive, setSysActive] = useState(true);
+  const [externalDeviceName, setExternalDeviceName] = useState<string | null>(null);
   const [showModels, setShowModels] = useState(false);
   const [showMcp, setShowMcp] = useState(false);
   const [focusMode, setFocusMode] = useState(false);
   const modelManager = useModelManager();
   openModelsRef.current = () => { modelManager.refresh(); setShowModels(true); };
 
+  // Detect external output device once the backend is ready.
+  useEffect(() => {
+    if (probe.kind !== "ok") return;
+    getOutputDeviceInfo()
+      .then((info) => {
+        if (info?.isHeadphones) setExternalDeviceName(info.name);
+      })
+      .catch(() => {});
+  }, [probe.kind]);
+
   // Pressing Start while viewing a stored meeting must also flip the
   // pane back to live so the user sees the new transcript.
   const handleStart = useCallback(async () => {
     goToLive();
-    await startRecording({ language, diarize });
-  }, [goToLive, startRecording, language, diarize]);
+    setMicActive(true);
+    setSysActive(true);
+    await startRecording({ language, diarize, source: audioSource });
+  }, [goToLive, startRecording, language, diarize, audioSource]);
+
+  const handleToggleMic = useCallback(async (active: boolean) => {
+    setMicActive(active);
+    await recordingSetMixSources(active, sysActive);
+  }, [recordingSetMixSources, sysActive]);
+
+  const handleToggleSys = useCallback(async (active: boolean) => {
+    setSysActive(active);
+    await recordingSetMixSources(micActive, active);
+  }, [recordingSetMixSources, micActive]);
 
   // Switching back to the live pane after a session finished must
   // also clear stale lines and reset the state machine to idle —
@@ -275,6 +303,13 @@ export function App() {
               onToggleDiarize={setDiarize}
               language={language}
               onChangeLanguage={setLanguage}
+              audioSource={audioSource}
+              onChangeSource={setAudioSource}
+              micActive={micActive}
+              sysActive={sysActive}
+              onToggleMic={handleToggleMic}
+              onToggleSys={handleToggleSys}
+              externalDeviceName={externalDeviceName}
               onStart={handleStart}
               onStop={stopRecording}
               onPause={recording.pause}

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,14 +1,16 @@
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Check, Copy } from "lucide-react";
 
 /** Small icon button that copies text to the clipboard. */
 export function CopyButton({
   getText,
-  title = "Copy",
+  title,
 }: Readonly<{
   getText: () => string;
   title?: string;
 }>) {
+  const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
 
   const handleClick = useCallback(() => {
@@ -23,7 +25,7 @@ export function CopyButton({
       type="button"
       onClick={handleClick}
       className="rounded-md p-1 text-content-tertiary hover:bg-surface-inset hover:text-content-primary"
-      title={title}
+      title={title ?? t("toast.copy")}
     >
       {copied ? (
         <Check className="h-3.5 w-3.5 text-emerald-500" />

--- a/src/features/live/HealthProbe.tsx
+++ b/src/features/live/HealthProbe.tsx
@@ -48,7 +48,7 @@ export function HealthProbe({ probe, onClickVersion }: Readonly<{ probe: Probe; 
           type="button"
           onClick={onClickVersion}
           className={`${base} cursor-pointer border-emerald-300 bg-emerald-50 text-emerald-800 hover:bg-emerald-100 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-950/60`}
-          title={`v${probe.status.version} · ${probe.status.target} · ${probe.status.commit}`}
+          title={t("health.tooltip", { version: probe.status.version, target: probe.status.target, commit: probe.status.commit })}
         >
           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
           {t("health.ok", { version: probe.status.version })}

--- a/src/features/live/LivePane.tsx
+++ b/src/features/live/LivePane.tsx
@@ -1,11 +1,12 @@
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { PanelLeft, Mic, Pause, Play } from "lucide-react";
+import { PanelLeft, Mic, MonitorSpeaker, Pause, Play, X } from "lucide-react";
 
 import { LogoAnimated } from "../../components/Logo";
 import { ResizableHandleVertical } from "../../components/ResizableHandleVertical";
 import type { RecordingState } from "../../state/recording";
+import type { AudioSourceKind } from "../../types/streaming";
 import type { Note } from "../../types/meeting";
 import type { StreamLine } from "../../types/view";
 import { NoteInput } from "./NoteInput";
@@ -75,6 +76,13 @@ export function LivePane({
   onToggleDiarize,
   language,
   onChangeLanguage,
+  audioSource,
+  onChangeSource,
+  micActive,
+  sysActive,
+  onToggleMic,
+  onToggleSys,
+  externalDeviceName,
   onStart,
   onStop,
   onPause,
@@ -97,6 +105,16 @@ export function LivePane({
   onToggleDiarize: (next: boolean) => void;
   language: string;
   onChangeLanguage: (next: string) => void;
+  audioSource: AudioSourceKind;
+  onChangeSource: (next: AudioSourceKind) => void;
+  /** Active mic flag for Mixed mode (undefined when not Mixed). */
+  micActive?: boolean;
+  /** Active sys flag for Mixed mode (undefined when not Mixed). */
+  sysActive?: boolean;
+  onToggleMic?: (active: boolean) => void;
+  onToggleSys?: (active: boolean) => void;
+  /** Device name for the external-output banner (null = hide banner). */
+  externalDeviceName: string | null;
   onStart: () => void;
   onStop: () => void;
   onPause: () => void;
@@ -108,6 +126,10 @@ export function LivePane({
   refineStage?: number;
 }>) {
   const { t } = useTranslation();
+
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+  const showExternalBanner =
+    externalDeviceName !== null && !bannerDismissed && audioSource !== "mixed";
 
   // Toggle is locked once a session is in flight
   const toggleLocked =
@@ -250,6 +272,27 @@ export function LivePane({
             <span className="text-content-secondary">{t("live.diarize")}</span>
           </label>
 
+          {/* Audio source selector */}
+          <label
+            className={`flex select-none items-center gap-1.5 text-ui-sm ${
+              toggleLocked ? "opacity-60" : "cursor-pointer"
+            }`}
+            title={t("live.sourceHint")}
+          >
+            <span className="text-content-tertiary">{t("live.sourceLabel")}</span>
+            <select
+              value={audioSource}
+              disabled={toggleLocked}
+              onChange={(e) => onChangeSource(e.target.value as AudioSourceKind)}
+              className="rounded border border-subtle bg-surface-elevated px-1.5 py-0.5 text-ui-sm text-content-primary"
+              aria-label={t("live.sourceLabel")}
+            >
+              <option value="microphone">{t("live.sourceMic")}</option>
+              <option value="systemOutput">{t("live.sourceSystem")}</option>
+              <option value="mixed">{t("live.sourceMixed")}</option>
+            </select>
+          </label>
+
           {/* Focus mode toggle — hides sidebar */}
           <button
             type="button"
@@ -266,6 +309,30 @@ export function LivePane({
           </button>
         </div>
       </header>
+
+      {/* ── External output device banner ── */}
+      {showExternalBanner && (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-blue-500/30 bg-blue-50 px-3 py-2 text-ui-sm dark:bg-blue-950/30">
+          <span className="text-blue-700 dark:text-blue-300">
+            {t("live.externalDeviceDetected", { device: externalDeviceName })}{" "}
+            <button
+              type="button"
+              onClick={() => { onChangeSource("mixed"); setBannerDismissed(true); }}
+              className="ml-1 font-semibold underline underline-offset-2 hover:no-underline"
+            >
+              {t("live.enableMixed")}
+            </button>
+          </span>
+          <button
+            type="button"
+            onClick={() => setBannerDismissed(true)}
+            aria-label={t("live.dismissBanner")}
+            className="flex-shrink-0 rounded p-0.5 text-blue-500 hover:bg-blue-100 dark:hover:bg-blue-900"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
 
       {/* ── Post-stop refining progress ── */}
       {stream.kind === "stopping" && refineStage != null && refineStage >= 0 && (
@@ -342,9 +409,13 @@ export function LivePane({
 
       {/* ── Bottom bar: controls + audio level ── */}
       <footer className="flex flex-shrink-0 items-center justify-between gap-4 rounded-md border border-subtle bg-surface-sunken px-4 py-2">
-        {/* Left: audio level indicator */}
+        {/* Left: audio level indicator + optional mix source toggles */}
         <div className="flex items-center gap-2">
-          <Mic className="h-3.5 w-3.5 text-content-tertiary" />
+          {audioSource === "systemOutput" ? (
+            <MonitorSpeaker className="h-3.5 w-3.5 text-content-tertiary" />
+          ) : (
+            <Mic className="h-3.5 w-3.5 text-content-tertiary" />
+          )}
           {/* Simple level bars */}
           <div className="flex items-end gap-0.5">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -364,6 +435,37 @@ export function LivePane({
             <span className="font-mono text-micro tabular-nums text-content-tertiary">
               {stats.chunks} {t("stats.chunks")}
             </span>
+          )}
+          {/* Mix source toggles — visible only during an active Mixed session */}
+          {audioSource === "mixed" && isActive && (
+            <div className="flex items-center gap-1 border-l border-subtle pl-2">
+              <button
+                type="button"
+                title={t("live.toggleMic")}
+                onClick={() => onToggleMic?.(!micActive)}
+                className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-micro ring-1 transition-colors ${
+                  micActive
+                    ? "bg-emerald-500/10 text-emerald-700 ring-emerald-500/30 dark:text-emerald-400"
+                    : "bg-content-placeholder/10 text-content-placeholder ring-content-placeholder/20 line-through"
+                }`}
+              >
+                <Mic className="h-2.5 w-2.5" />
+                {t("live.mic")}
+              </button>
+              <button
+                type="button"
+                title={t("live.toggleSys")}
+                onClick={() => onToggleSys?.(!sysActive)}
+                className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-micro ring-1 transition-colors ${
+                  sysActive
+                    ? "bg-violet-500/10 text-violet-700 ring-violet-500/30 dark:text-violet-400"
+                    : "bg-content-placeholder/10 text-content-placeholder ring-content-placeholder/20 line-through"
+                }`}
+              >
+                <MonitorSpeaker className="h-2.5 w-2.5" />
+                {t("live.sys")}
+              </button>
+            </div>
           )}
         </div>
 

--- a/src/features/live/LivePane.tsx
+++ b/src/features/live/LivePane.tsx
@@ -1,7 +1,7 @@
 import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { PanelLeft, Mic, MonitorSpeaker, Pause, Play, X } from "lucide-react";
+import { ChevronDown, Globe, PanelLeft, Mic, MonitorSpeaker, Pause, Play, Users, X } from "lucide-react";
 
 import { LogoAnimated } from "../../components/Logo";
 import { ResizableHandleVertical } from "../../components/ResizableHandleVertical";
@@ -141,6 +141,12 @@ export function LivePane({
   const isActive =
     stream.kind === "recording" || stream.kind === "paused";
 
+  const sourceLabels: Record<AudioSourceKind, string> = {
+    microphone: t("live.sourceMic"),
+    systemOutput: t("live.sourceSystem"),
+    mixed: t("live.sourceMixed"),
+  };
+
   // Focus mode: hides the sidebar (history panel)
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -230,77 +236,115 @@ export function LivePane({
           )}
         </div>
 
-        <div className="flex items-center gap-3">
-          {/* Language selector */}
-          <label
-            className={`flex select-none items-center gap-1.5 text-ui-sm ${
-              toggleLocked ? "opacity-60" : "cursor-pointer"
+        <div className="flex items-center gap-2">
+          {/* Unified capture controls — language · voices · source */}
+          <div
+            className={`flex items-center divide-x divide-subtle rounded-lg border border-subtle bg-surface-elevated text-ui-sm ${
+              toggleLocked ? "opacity-60" : ""
             }`}
-            title={t("live.langHint")}
           >
-            <span className="text-content-tertiary">{t("live.langLabel")}</span>
-            <select
-              value={language}
-              disabled={toggleLocked}
-              onChange={(e) => onChangeLanguage(e.target.value)}
-              className="rounded border border-subtle bg-surface-elevated px-1.5 py-0.5 text-ui-sm text-content-primary"
-              aria-label={t("live.langTooltip")}
+            {/* Language */}
+            <label
+              className={`relative flex select-none items-center gap-1.5 px-2.5 py-1 ${
+                toggleLocked ? "" : "cursor-pointer"
+              }`}
+              title={t("live.langHint")}
             >
-              <option value="">{t("live.langAuto")}</option>
-              <option value="es">{t("languages.es")}</option>
-              <option value="en">{t("languages.en")}</option>
-              <option value="pt">{t("languages.pt")}</option>
-              <option value="fr">{t("languages.fr")}</option>
-              <option value="de">{t("languages.de")}</option>
-              <option value="it">{t("languages.it")}</option>
-            </select>
-          </label>
+              <Globe className="h-3.5 w-3.5 shrink-0 text-content-tertiary" aria-hidden />
+              <span className="relative inline-flex items-center pr-4 text-content-primary">
+                <span aria-hidden>
+                  {language === "" ? t("live.langAuto") : t(`languages.${language}`)}
+                </span>
+                <select
+                  value={language}
+                  disabled={toggleLocked}
+                  onChange={(e) => onChangeLanguage(e.target.value)}
+                  className="absolute inset-0 w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-ui-sm text-transparent opacity-0 focus:opacity-0 focus:outline-none focus:ring-0"
+                  aria-label={t("live.langTooltip")}
+                >
+                  <option value="">{t("live.langAuto")}</option>
+                  <option value="es">{t("languages.es")}</option>
+                  <option value="en">{t("languages.en")}</option>
+                  <option value="pt">{t("languages.pt")}</option>
+                  <option value="fr">{t("languages.fr")}</option>
+                  <option value="de">{t("languages.de")}</option>
+                  <option value="it">{t("languages.it")}</option>
+                </select>
+                <ChevronDown
+                  className="pointer-events-none absolute right-0 h-3 w-3 text-content-tertiary"
+                  aria-hidden
+                />
+              </span>
+            </label>
 
-          {/* Diarize toggle */}
-          <label
-            className={`flex select-none items-center gap-1.5 text-ui-sm ${
-              toggleLocked ? "opacity-60" : "cursor-pointer"
-            }`}
-          >
-            <input
-              type="checkbox"
-              checked={diarize}
+            {/* Voices (formerly Diarize) */}
+            <button
+              type="button"
+              onClick={() => !toggleLocked && onToggleDiarize(!diarize)}
               disabled={toggleLocked}
-              onChange={(e) => onToggleDiarize(e.target.checked)}
-              className=""
-            />
-            <span className="text-content-secondary">{t("live.diarize")}</span>
-          </label>
-
-          {/* Audio source selector */}
-          <label
-            className={`flex select-none items-center gap-1.5 text-ui-sm ${
-              toggleLocked ? "opacity-60" : "cursor-pointer"
-            }`}
-            title={t("live.sourceHint")}
-          >
-            <span className="text-content-tertiary">{t("live.sourceLabel")}</span>
-            <select
-              value={audioSource}
-              disabled={toggleLocked}
-              onChange={(e) => onChangeSource(e.target.value as AudioSourceKind)}
-              className="rounded border border-subtle bg-surface-elevated px-1.5 py-0.5 text-ui-sm text-content-primary"
-              aria-label={t("live.sourceLabel")}
+              role="switch"
+              aria-checked={diarize}
+              title={t("live.diarizeHint")}
+              className={`flex select-none items-center gap-1.5 px-2.5 py-1 transition-colors ${
+                toggleLocked ? "" : "cursor-pointer hover:bg-surface-sunken"
+              } ${
+                diarize
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-content-secondary"
+              }`}
             >
-              <option value="microphone">{t("live.sourceMic")}</option>
-              <option value="systemOutput">{t("live.sourceSystem")}</option>
-              <option value="mixed">{t("live.sourceMixed")}</option>
-            </select>
-          </label>
+              <Users
+                className={`h-3.5 w-3.5 ${diarize ? "text-emerald-600 dark:text-emerald-400" : "text-content-tertiary"}`}
+                aria-hidden
+              />
+              <span>{t("live.diarize")}</span>
+              <span
+                className={`ml-0.5 inline-block h-2 w-2 rounded-full ${
+                  diarize
+                    ? "bg-emerald-500 shadow-[0_0_0_2px_rgba(16,185,129,0.18)]"
+                    : "border border-content-placeholder/50"
+                }`}
+                aria-hidden
+              />
+            </button>
+
+            {/* Audio source */}
+            <label
+              className={`relative flex select-none items-center gap-1.5 px-2.5 py-1 ${
+                toggleLocked ? "" : "cursor-pointer"
+              }`}
+              title={t("live.sourceHint")}
+            >
+              <Mic className="h-3.5 w-3.5 shrink-0 text-content-tertiary" aria-hidden />
+              <span className="relative inline-flex items-center pr-4 text-content-primary">
+                <span aria-hidden>{sourceLabels[audioSource]}</span>
+                <select
+                  value={audioSource}
+                  disabled={toggleLocked}
+                  onChange={(e) => onChangeSource(e.target.value as AudioSourceKind)}
+                  className="absolute inset-0 w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-ui-sm text-transparent opacity-0 focus:opacity-0 focus:outline-none focus:ring-0"
+                  aria-label={t("live.sourceLabel")}
+                >
+                  <option value="microphone">{t("live.sourceMic")}</option>
+                  <option value="systemOutput">{t("live.sourceSystem")}</option>
+                  <option value="mixed">{t("live.sourceMixed")}</option>
+                </select>
+                <ChevronDown
+                  className="pointer-events-none absolute right-0 h-3 w-3 text-content-tertiary"
+                  aria-hidden
+                />
+              </span>
+            </label>
+          </div>
 
           {/* Focus mode toggle — hides sidebar */}
           <button
             type="button"
             onClick={onToggleFocusMode}
-            className={`rounded px-1.5 py-0.5 text-ui-xs transition-colors ${
+            className={`rounded-lg border px-2 py-1 text-ui-xs transition-colors ${
               focusMode
-                ? "bg-accent-100 text-accent-700 dark:text-accent-400"
-                : "text-content-tertiary hover:text-content-secondary"
+                ? "border-accent-400 bg-accent-100 text-accent-700 dark:border-accent-700 dark:bg-accent-900/30 dark:text-accent-400"
+                : "border-subtle text-content-tertiary hover:text-content-secondary"
             }`}
             title={t("live.focusMode", { shortcut: FOCUS_SHORTCUT })}
             aria-label={t("live.toggleFocusMode")}

--- a/src/features/live/LivePane.tsx
+++ b/src/features/live/LivePane.tsx
@@ -225,12 +225,12 @@ export function LivePane({
               aria-label={t("live.langTooltip")}
             >
               <option value="">{t("live.langAuto")}</option>
-              <option value="es">es</option>
-              <option value="en">en</option>
-              <option value="pt">pt</option>
-              <option value="fr">fr</option>
-              <option value="de">de</option>
-              <option value="it">it</option>
+              <option value="es">{t("languages.es")}</option>
+              <option value="en">{t("languages.en")}</option>
+              <option value="pt">{t("languages.pt")}</option>
+              <option value="fr">{t("languages.fr")}</option>
+              <option value="de">{t("languages.de")}</option>
+              <option value="it">{t("languages.it")}</option>
             </select>
           </label>
 
@@ -259,8 +259,8 @@ export function LivePane({
                 ? "bg-accent-100 text-accent-700 dark:text-accent-400"
                 : "text-content-tertiary hover:text-content-secondary"
             }`}
-            title={`Focus mode (${FOCUS_SHORTCUT})`}
-            aria-label="Toggle focus mode"
+            title={t("live.focusMode", { shortcut: FOCUS_SHORTCUT })}
+            aria-label={t("live.toggleFocusMode")}
           >
             <PanelLeft className="h-3.5 w-3.5 inline-block" />
           </button>

--- a/src/features/meetings/ChatPanel.tsx
+++ b/src/features/meetings/ChatPanel.tsx
@@ -32,6 +32,7 @@ import {
 import { useTranslation } from "react-i18next";
 import i18next from "i18next";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
 import { Clock } from "lucide-react";
 
@@ -321,7 +322,7 @@ function AssistantContent({
 
   return (
     <div className="prose prose-sm max-w-none [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0 [&_h1]:text-ui-md [&_h2]:text-ui-md [&_h3]:text-ui-sm [&_h4]:text-ui-sm [&_pre]:text-ui-sm">
-      <Markdown rehypePlugins={[rehypeSanitize]} components={mdComponents}>
+      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} components={mdComponents}>
         {cleaned}
       </Markdown>
       {hadCitations === false && (

--- a/src/features/meetings/MeetingDetail.tsx
+++ b/src/features/meetings/MeetingDetail.tsx
@@ -211,7 +211,7 @@ export function MeetingDetail({
       )}
 
       {/* ── Tab bar ── */}
-      <nav className="flex gap-1 border-b border-subtle" aria-label="Meeting sections">
+      <nav className="flex gap-1 border-b border-subtle" aria-label={t("meeting.sectionsNav")}>
         {tabs.map((tab) => (
           <button
             key={tab.id}

--- a/src/features/meetings/SpeakerEditor.tsx
+++ b/src/features/meetings/SpeakerEditor.tsx
@@ -58,7 +58,7 @@ export const SpeakerEditor = memo(function SpeakerEditor({
             e.currentTarget.blur();
           }
         }}
-        aria-label={t("speakers.rename", { name: displayName(speaker) })}
+        aria-label={t("speakers.rename", { name: displayName(speaker, t) })}
         className="w-28 bg-transparent outline-none placeholder:text-current placeholder:opacity-60"
       />
       {talkTimePct != null && talkTimePct > 0 && (

--- a/src/features/meetings/SummaryPanel.tsx
+++ b/src/features/meetings/SummaryPanel.tsx
@@ -24,7 +24,7 @@ import { CopyButton } from "../../components/CopyButton";
 import { LogoAnimated } from "../../components/Logo";
 import { formatDate } from "../../lib/format";
 import type { Summary, TemplateId } from "../../types/summary";
-import { TEMPLATE_IDS, TEMPLATE_LABELS } from "../../types/summary";
+import { TEMPLATE_IDS, TEMPLATE_LABEL_KEYS } from "../../types/summary";
 import type { UseMeetingSummary, SelectedTemplate } from "../../hooks/useMeetingSummary";
 import type { CustomTemplate } from "../../types/custom-template";
 import { listCustomTemplates } from "../../ipc/client";
@@ -183,7 +183,7 @@ function TemplateSelector({
     >
       {TEMPLATE_IDS.map((id) => (
         <option key={id} value={id}>
-          {TEMPLATE_LABELS[id]}
+          {t(TEMPLATE_LABEL_KEYS[id])}
         </option>
       ))}
       {customTemplates.length > 0 && (

--- a/src/features/meetings/SummaryPanel.tsx
+++ b/src/features/meetings/SummaryPanel.tsx
@@ -18,8 +18,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import rehypeSanitize from "rehype-sanitize";
-import { Settings, FileText } from "lucide-react";
+import { ChevronDown, FileText, SquarePen, StickyNote } from "lucide-react";
 import { CopyButton } from "../../components/CopyButton";
 import { LogoAnimated } from "../../components/Logo";
 import { formatDate } from "../../lib/format";
@@ -63,31 +64,57 @@ export function SummaryPanel({
         <span className="type-section-header text-content-placeholder">
           {t("summary.label")}
         </span>
-        <div className="flex items-center gap-1.5">
-          <TemplateSelector
-            value={selectedTemplate}
-            onChange={setSelectedTemplate}
-            disabled={loading || generating}
-            customTemplates={customTemplates}
-          />
-          <button
-            type="button"
-            onClick={() => setShowTemplateManager(true)}
-            className="rounded-md p-1 text-content-tertiary hover:bg-surface-inset hover:text-content-primary"
-            title={t("templates.manage")}
+        <div className="flex items-center gap-2">
+          {/* Unified summary controls — template · manage · include notes */}
+          <div
+            className={`flex items-center divide-x divide-subtle rounded-lg border border-subtle bg-surface-elevated text-ui-sm ${
+              loading || generating ? "opacity-60" : ""
+            }`}
           >
-            <Settings className="h-3.5 w-3.5" />
-          </button>
-          <label className="flex cursor-pointer items-center gap-1 text-ui-xs text-content-tertiary">
-            <input
-              type="checkbox"
-              checked={includeNotes}
-              onChange={(e) => setIncludeNotes(e.target.checked)}
+            <TemplateSelector
+              value={selectedTemplate}
+              onChange={setSelectedTemplate}
               disabled={loading || generating}
-              className=""
+              customTemplates={customTemplates}
             />
-            {t("summary.includeNotes")}
-          </label>
+            <button
+              type="button"
+              onClick={() => setShowTemplateManager(true)}
+              disabled={loading || generating}
+              className="flex select-none items-center gap-1.5 px-2.5 py-1 text-content-secondary transition-colors hover:bg-surface-sunken hover:text-content-primary disabled:cursor-not-allowed"
+              title={t("templates.manage")}
+            >
+              <SquarePen className="h-3.5 w-3.5 text-content-tertiary" aria-hidden />
+              <span>{t("templates.manageShort")}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => setIncludeNotes(!includeNotes)}
+              disabled={loading || generating}
+              role="switch"
+              aria-checked={includeNotes}
+              title={t("summary.includeNotes")}
+              className={`flex select-none items-center gap-1.5 px-2.5 py-1 transition-colors hover:bg-surface-sunken disabled:cursor-not-allowed ${
+                includeNotes
+                  ? "text-emerald-700 dark:text-emerald-400"
+                  : "text-content-secondary"
+              }`}
+            >
+              <StickyNote
+                className={`h-3.5 w-3.5 ${includeNotes ? "text-emerald-600 dark:text-emerald-400" : "text-content-tertiary"}`}
+                aria-hidden
+              />
+              <span>{t("summary.includeNotes")}</span>
+              <span
+                className={`ml-0.5 inline-block h-2 w-2 rounded-full ${
+                  includeNotes
+                    ? "bg-emerald-500 shadow-[0_0_0_2px_rgba(16,185,129,0.18)]"
+                    : "border border-content-placeholder/50"
+                }`}
+                aria-hidden
+              />
+            </button>
+          </div>
           {summary && <CopyButton getText={getSummaryText} title={t("meeting.copySummary")} />}
           <SummaryActions
             summary={summary}
@@ -121,7 +148,7 @@ export function SummaryPanel({
         )}
         {!loading && generating && streamingText && (
           <div className="prose prose-sm max-w-none text-ui-md leading-relaxed">
-            <Markdown rehypePlugins={[rehypeSanitize]}>{streamingText}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>{streamingText}</Markdown>
             <span className="ml-0.5 inline-block h-3 w-1.5 animate-pulse rounded-sm bg-emerald-500" />
           </div>
         )}
@@ -174,28 +201,48 @@ function TemplateSelector({
     }
   };
 
+  const currentLabel =
+    value.kind === "builtin"
+      ? t(TEMPLATE_LABEL_KEYS[value.id])
+      : value.name;
+
   return (
-    <select
-      value={selectValue}
-      onChange={(e) => handleChange(e.target.value)}
-      disabled={disabled}
-      className="rounded-md border bg-surface-elevated px-1.5 py-1 text-ui-sm disabled:opacity-60"
+    <label
+      className={`relative flex select-none items-center gap-1.5 px-2.5 py-1 ${
+        disabled ? "" : "cursor-pointer"
+      }`}
     >
-      {TEMPLATE_IDS.map((id) => (
-        <option key={id} value={id}>
-          {t(TEMPLATE_LABEL_KEYS[id])}
-        </option>
-      ))}
-      {customTemplates.length > 0 && (
-        <optgroup label={t("templates.customGroup")}>
-          {customTemplates.map((ct) => (
-            <option key={ct.id} value={`custom:${ct.id}`}>
-              {ct.name}
+      <FileText className="h-3.5 w-3.5 shrink-0 text-content-tertiary" aria-hidden />
+      <span className="relative inline-flex items-center pr-4 text-content-primary">
+        <span aria-hidden>{currentLabel}</span>
+        <select
+          value={selectValue}
+          onChange={(e) => handleChange(e.target.value)}
+          disabled={disabled}
+          className="absolute inset-0 w-full cursor-pointer appearance-none border-0 bg-transparent p-0 text-ui-sm text-transparent opacity-0 focus:opacity-0 focus:outline-none focus:ring-0"
+          aria-label={t("summary.label")}
+        >
+          {TEMPLATE_IDS.map((id) => (
+            <option key={id} value={id}>
+              {t(TEMPLATE_LABEL_KEYS[id])}
             </option>
           ))}
-        </optgroup>
-      )}
-    </select>
+          {customTemplates.length > 0 && (
+            <optgroup label={t("templates.customGroup")}>
+              {customTemplates.map((ct) => (
+                <option key={ct.id} value={`custom:${ct.id}`}>
+                  {ct.name}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+        <ChevronDown
+          className="pointer-events-none absolute right-0 h-3 w-3 text-content-tertiary"
+          aria-hidden
+        />
+      </span>
+    </label>
   );
 }
 
@@ -224,7 +271,7 @@ function SummaryActions({
       type="button"
       onClick={onGenerate}
       disabled={disabled}
-      className="rounded-md border bg-surface-elevated px-2 py-1 text-ui-sm font-medium hover:bg-surface-sunken disabled:cursor-not-allowed disabled:opacity-60"
+      className="rounded-lg border border-accent-600 bg-accent-600 px-3 py-1 text-ui-sm font-medium text-white shadow-sm transition-colors hover:bg-accent-700 disabled:cursor-not-allowed disabled:opacity-60 dark:border-accent-400 dark:bg-accent-400 dark:text-content-primary dark:hover:bg-accent-600"
     >
       {label}
     </button>
@@ -330,7 +377,7 @@ function renderTemplateBody(summary: Summary, t: (key: string) => string) {
     case "freeText":
       return (
         <div className="prose prose-sm max-w-none">
-          <Markdown rehypePlugins={[rehypeSanitize]}>{summary.text || t("summary.emptySummary")}</Markdown>
+          <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>{summary.text || t("summary.emptySummary")}</Markdown>
         </div>
       );
 
@@ -341,7 +388,7 @@ function renderTemplateBody(summary: Summary, t: (key: string) => string) {
             {summary.templateName}
           </p>
           <div className="prose prose-sm max-w-none">
-            <Markdown rehypePlugins={[rehypeSanitize]}>{summary.text || t("summary.emptySummary")}</Markdown>
+            <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>{summary.text || t("summary.emptySummary")}</Markdown>
           </div>
         </div>
       );

--- a/src/hooks/useHardwareRecommendation.ts
+++ b/src/hooks/useHardwareRecommendation.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import type { ModelRecommendation } from "../types/hardware";
 import { getModelRecommendation } from "../ipc/client";
@@ -8,6 +9,7 @@ import { getModelRecommendation } from "../ipc/client";
  * Caches the result for the lifetime of the component.
  */
 export function useHardwareRecommendation() {
+  const { t } = useTranslation();
   const [data, setData] = useState<ModelRecommendation | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -20,7 +22,7 @@ export function useHardwareRecommendation() {
       })
       .catch((err: unknown) => {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : "Unknown error";
+          const message = err instanceof Error ? err.message : t("errors.unknownError");
           setError(message);
         }
       })

--- a/src/hooks/useRecordingSession.ts
+++ b/src/hooks/useRecordingSession.ts
@@ -26,7 +26,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useToast } from "../components/Toaster";
-import { startStreaming, stopStreaming, pauseStreaming, resumeStreaming, addNote as ipcAddNote, getMeetingId } from "../ipc/client";
+import { startStreaming, stopStreaming, pauseStreaming, resumeStreaming, addNote as ipcAddNote, getMeetingId, setMixSources as ipcSetMixSources } from "../ipc/client";
 import { isIpcError } from "../types/ipc-error";
 import type { ErrorCode } from "../types/ipc-error";
 import {
@@ -37,7 +37,7 @@ import {
   initialRecordingState,
   recordingReducer,
 } from "../state/recording";
-import type { TranscriptEvent } from "../types/streaming";
+import type { AudioSourceKind, TranscriptEvent } from "../types/streaming";
 import type { Note } from "../types/meeting";
 import type { StreamLine } from "../types/view";
 
@@ -57,6 +57,8 @@ export type StartOptions = {
   language: string;
   /** Enable diarization for this session. */
   diarize: boolean;
+  /** Audio capture source. Defaults to microphone. */
+  source?: AudioSourceKind;
 };
 
 export function useRecordingSession({
@@ -248,7 +250,7 @@ export function useRecordingSession({
   }, [t]);
 
   const start = useCallback(
-    async ({ language, diarize }: StartOptions) => {
+    async ({ language, diarize, source }: StartOptions) => {
       setLines([]);
       setStats(ZERO_STATS);
       setNotes([]);
@@ -263,6 +265,7 @@ export function useRecordingSession({
             silenceRmsThreshold: 0.005,
             diarize,
             ...(langHint.length > 0 ? { language: langHint } : {}),
+            ...(source && source !== "microphone" ? { source } : {}),
           },
           handleEvent,
         );
@@ -381,6 +384,14 @@ export function useRecordingSession({
     [stream],
   );
 
+  const setMixSources = useCallback(
+    async (micActive: boolean, sysActive: boolean): Promise<void> => {
+      if (stream.kind !== "recording" && stream.kind !== "paused") return;
+      await ipcSetMixSources(stream.sessionId, micActive, sysActive).catch(() => {});
+    },
+    [stream],
+  );
+
   const canStart = backendReady && selectCanStart(stream);
   const canStop = selectCanStop(stream);
   const canPause = selectCanPause(stream);
@@ -418,5 +429,6 @@ export function useRecordingSession({
     addNote,
     dismissError,
     reset,
+    setMixSources,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -28,7 +28,7 @@
     "langHint": "Hint passed to whisper. 'auto' lets the model detect.",
     "langLabel": "Lang",
     "langTooltip": "Transcription language",
-    "langAuto": "auto",
+    "langAuto": "Auto",
     "diarize": "Diarize",
     "starting": "Starting…",
     "start": "Start",
@@ -43,6 +43,8 @@
     "fatal": "fatal:",
     "dismiss": "dismiss",
     "listening": "Listening… speak into the microphone.",
+    "focusMode": "Focus mode ({{shortcut}})",
+    "toggleFocusMode": "Toggle focus mode",
     "pressStart": "Press Start or {{shortcut}} to begin a session.",
     "modelLoads": "model loads on first start",
     "silence": "silence",
@@ -74,7 +76,8 @@
     "copySummary": "Copy summary",
     "copyTranscript": "Copy transcript",
     "copyNotes": "Copy notes",
-    "editTitle": "Click to rename"
+    "editTitle": "Click to rename",
+    "sectionsNav": "Meeting sections"
   },
   "export": {
     "markdown": "Markdown (.md)",
@@ -195,7 +198,15 @@
     "namePlaceholder": "Template name…",
     "promptPlaceholder": "Write your summary prompt here… The meeting transcript will be appended automatically.",
     "manage": "Manage templates",
-    "customGroup": "Custom"
+    "customGroup": "Custom",
+    "builtIn": {
+      "general": "General",
+      "oneOnOne": "1:1",
+      "sprintReview": "Sprint Review",
+      "interview": "Interview",
+      "salesCall": "Sales Call",
+      "lecture": "Lecture"
+    }
   },
   "onboarding": {
     "welcomeSubtitle": "Private transcription and smart summaries for your meetings.",
@@ -258,6 +269,7 @@
     "modelMissingDetail": "Download the missing model from the Models panel to use this feature.",
     "openModels": "Open Models",
     "outsideTauri": "Running outside Tauri — IPC is unavailable in pnpm dev. Use pnpm tauri:dev.",
+    "unknownError": "Unknown error",
     "healthFailed": "Backend health check failed."
   },
   "toast": {
@@ -291,6 +303,14 @@
     "failed": "Update failed",
     "checking": "Checking for updates…",
     "upToDate": "You're up to date!"
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "pt": "Português",
+    "fr": "Français",
+    "de": "Deutsch",
+    "it": "Italiano"
   },
   "settings": {
     "switchLanguage": "Switch language",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "EchoNote",
-    "subtitle": "Private, local-first meeting transcription and AI summaries."
+    "subtitle": "Private, local-first meeting transcription and AI summaries.",
+    "privacyChip": "100% local"
   },
   "sidebar": {
     "meetings": "Meetings",
@@ -26,10 +27,11 @@
     "title": "Live transcript",
     "description": "5-second windows · whisper.cpp · {{label}}",
     "langHint": "Hint passed to whisper. 'auto' lets the model detect.",
-    "langLabel": "Lang",
+    "langLabel": "Language",
     "langTooltip": "Transcription language",
     "langAuto": "Auto",
-    "diarize": "Diarize",
+    "diarize": "Voices",
+    "diarizeHint": "Identify and separate each person speaking",
     "starting": "Starting…",
     "start": "Start",
     "recording": "Recording…",
@@ -210,6 +212,7 @@
     "namePlaceholder": "Template name…",
     "promptPlaceholder": "Write your summary prompt here… The meeting transcript will be appended automatically.",
     "manage": "Manage templates",
+    "manageShort": "Templates",
     "customGroup": "Custom",
     "builtIn": {
       "general": "General",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -55,7 +55,19 @@
     "notes": "Notes",
     "refineTranscript": "Refining transcript…",
     "refineSpeakers": "Detecting speakers…",
-    "refineSummary": "Generating summary…"
+    "refineSummary": "Generating summary…",
+    "sourceLabel": "Source",
+    "sourceHint": "Audio source for transcription",
+    "sourceMic": "Microphone",
+    "sourceSystem": "System audio",
+    "sourceMixed": "Mixed (mic + system)",
+    "externalDeviceDetected": "External output detected: {{device}}.",
+    "enableMixed": "Enable mixed mode",
+    "dismissBanner": "Dismiss",
+    "toggleMic": "Toggle microphone in mix",
+    "toggleSys": "Toggle system audio in mix",
+    "mic": "Mic",
+    "sys": "Sys"
   },
   "health": {
     "warmingUp": "warming up…",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -55,7 +55,19 @@
     "notes": "Notas",
     "refineTranscript": "Afinando transcripción…",
     "refineSpeakers": "Detectando speakers…",
-    "refineSummary": "Generando resumen…"
+    "refineSummary": "Generando resumen…",
+    "sourceLabel": "Fuente",
+    "sourceHint": "Fuente de audio para la transcripción",
+    "sourceMic": "Micrófono",
+    "sourceSystem": "Audio del sistema",
+    "sourceMixed": "Mixto (mic + sistema)",
+    "externalDeviceDetected": "Dispositivo de salida externo detectado: {{device}}.",
+    "enableMixed": "Activar modo mixto",
+    "dismissBanner": "Cerrar aviso",
+    "toggleMic": "Activar/desactivar micrófono en la mezcla",
+    "toggleSys": "Activar/desactivar audio del sistema en la mezcla",
+    "mic": "Mic",
+    "sys": "Sys"
   },
   "health": {
     "warmingUp": "calentando…",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -28,7 +28,7 @@
     "langHint": "Pista para whisper. 'auto' deja que el modelo detecte.",
     "langLabel": "Idioma",
     "langTooltip": "Idioma de transcripción",
-    "langAuto": "auto",
+    "langAuto": "Auto",
     "diarize": "Diarizar",
     "starting": "Iniciando…",
     "start": "Iniciar",
@@ -43,6 +43,8 @@
     "fatal": "fatal:",
     "dismiss": "cerrar",
     "listening": "Escuchando… habla por el micrófono.",
+    "focusMode": "Modo enfoque ({{shortcut}})",
+    "toggleFocusMode": "Alternar modo enfoque",
     "pressStart": "Pulsa Iniciar o {{shortcut}} para comenzar una sesión.",
     "modelLoads": "el modelo se carga en el primer inicio",
     "silence": "silencio",
@@ -74,7 +76,8 @@
     "copySummary": "Copiar resumen",
     "copyTranscript": "Copiar transcripción",
     "copyNotes": "Copiar notas",
-    "editTitle": "Clic para renombrar"
+    "editTitle": "Clic para renombrar",
+    "sectionsNav": "Secciones de la reunión"
   },
   "export": {
     "markdown": "Markdown (.md)",
@@ -195,7 +198,15 @@
     "namePlaceholder": "Nombre de la plantilla…",
     "promptPlaceholder": "Escribe tu prompt de resumen aquí… La transcripción de la reunión se agregará automáticamente.",
     "manage": "Gestionar plantillas",
-    "customGroup": "Personalizadas"
+    "customGroup": "Personalizadas",
+    "builtIn": {
+      "general": "General",
+      "oneOnOne": "1:1",
+      "sprintReview": "Revisión de Sprint",
+      "interview": "Entrevista",
+      "salesCall": "Llamada de Ventas",
+      "lecture": "Clase / Conferencia"
+    }
   },
   "onboarding": {
     "welcomeSubtitle": "Transcripción privada y resúmenes inteligentes para tus reuniones.",
@@ -258,6 +269,7 @@
     "modelMissingDetail": "Descarga el modelo faltante desde el panel de Modelos para usar esta función.",
     "openModels": "Abrir Modelos",
     "outsideTauri": "Fuera de Tauri — IPC no disponible con pnpm dev. Usa pnpm tauri:dev.",
+    "unknownError": "Error desconocido",
     "healthFailed": "Falló la verificación del backend."
   },
   "toast": {
@@ -291,6 +303,14 @@
     "failed": "Error al actualizar",
     "checking": "Buscando actualizaciones…",
     "upToDate": "¡Estás al día!"
+  },
+  "languages": {
+    "es": "Español",
+    "en": "English",
+    "pt": "Português",
+    "fr": "Français",
+    "de": "Deutsch",
+    "it": "Italiano"
   },
   "settings": {
     "switchLanguage": "Cambiar idioma",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,7 +1,8 @@
 {
   "app": {
     "title": "EchoNote",
-    "subtitle": "Transcripción de reuniones privada y local con resúmenes de IA."
+    "subtitle": "Transcripción de reuniones privada y local con resúmenes de IA.",
+    "privacyChip": "100% local"
   },
   "sidebar": {
     "meetings": "Reuniones",
@@ -29,7 +30,8 @@
     "langLabel": "Idioma",
     "langTooltip": "Idioma de transcripción",
     "langAuto": "Auto",
-    "diarize": "Diarizar",
+    "diarize": "Voces",
+    "diarizeHint": "Identifica y separa a cada persona que habla",
     "starting": "Iniciando…",
     "start": "Iniciar",
     "recording": "Grabando…",
@@ -210,6 +212,7 @@
     "namePlaceholder": "Nombre de la plantilla…",
     "promptPlaceholder": "Escribe tu prompt de resumen aquí… La transcripción de la reunión se agregará automáticamente.",
     "manage": "Gestionar plantillas",
+    "manageShort": "Plantillas",
     "customGroup": "Personalizadas",
     "builtIn": {
       "general": "General",

--- a/src/ipc/bindings.ts
+++ b/src/ipc/bindings.ts
@@ -79,6 +79,29 @@ async getMeetingId(sessionId: StreamingSessionId) : Promise<Result<MeetingId | n
 }
 },
 /**
+ * Return the name and headphone-heuristic for the default output device.
+ */
+async getOutputDeviceInfo() : Promise<Result<OutputDeviceInfo | null, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_output_device_info") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Toggle which sources contribute to the mix for an active `Mixed` session.
+ * Returns `false` when the session is not found or was not started in Mixed mode.
+ */
+async setMixSources(sessionId: StreamingSessionId, micActive: boolean, sysActive: boolean) : Promise<Result<boolean, IpcError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_mix_sources", { sessionId, micActive, sysActive }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * List meetings, newest first.
  */
 async listMeetings(limit: number | null) : Promise<Result<MeetingSummary[], IpcError>> {
@@ -884,7 +907,12 @@ export type IpcAudioSource =
 /**
  * System audio loopback (macOS 13+ via ScreenCaptureKit).
  */
-"systemOutput"
+"systemOutput" | 
+/**
+ * Microphone + system audio merged. Both sources run concurrently;
+ * each can be muted/unmuted live via `set_mix_sources`.
+ */
+"mixed"
 /**
  * Structured error returned by every Tauri command.
  * 
@@ -1151,6 +1179,19 @@ createdAt: string }
  * ordering aligned with creation time.
  */
 export type NoteId = string
+/**
+ * Information about the current system audio output device.
+ */
+export type OutputDeviceInfo = { 
+/**
+ * Human-readable name of the default output device.
+ */
+name: string; 
+/**
+ * Heuristic: `true` when the device name suggests headphones /
+ * earbuds / in-ear monitors rather than built-in or external speakers.
+ */
+isHeadphones: boolean }
 /**
  * One contiguous transcription span.
  * 

--- a/src/ipc/client.ts
+++ b/src/ipc/client.ts
@@ -28,6 +28,7 @@ import type {
 } from "../types/meeting";
 import type { SpeakerId } from "../types/speaker";
 import type {
+  OutputDeviceInfo,
   StartStreamingOptions,
   StreamingSessionId,
   TranscriptEvent,
@@ -107,6 +108,27 @@ export async function getMeetingId(
   sessionId: StreamingSessionId,
 ): Promise<MeetingId | null> {
   return invoke<MeetingId | null>("get_meeting_id", { sessionId });
+}
+
+/**
+ * Get the name and headphone-heuristic for the default audio output device.
+ * Returns `null` when no output device is available.
+ */
+export async function getOutputDeviceInfo(): Promise<OutputDeviceInfo | null> {
+  return invoke<OutputDeviceInfo | null>("get_output_device_info");
+}
+
+/**
+ * Toggle which sources contribute to the mix for an active `mixed` session.
+ * Returns `true` when the session was found and has mix controls.
+ * No-op (returns `false`) for non-Mixed sessions.
+ */
+export async function setMixSources(
+  sessionId: StreamingSessionId,
+  micActive: boolean,
+  sysActive: boolean,
+): Promise<boolean> {
+  return invoke<boolean>("set_mix_sources", { sessionId, micActive, sysActive });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/speakers.ts
+++ b/src/lib/speakers.ts
@@ -14,6 +14,7 @@
  * transcript backgrounds without per-theme overrides.
  */
 
+import type { TFunction } from "i18next";
 import type { Speaker } from "../types/speaker";
 
 /**
@@ -52,10 +53,17 @@ export function paletteFor(slot: number): SpeakerPaletteEntry {
  * Rust side: trimmed user label when present, otherwise
  * `Speaker {slot+1}`. Whitespace-only labels fall back to anonymous
  * so the UI never renders an empty chip.
+ *
+ * When a `t` function is provided, the fallback uses i18n; otherwise
+ * it falls back to English for non-React contexts (export, copy).
  */
-export function displayName(speaker: Pick<Speaker, "slot" | "label">): string {
+export function displayName(
+  speaker: Pick<Speaker, "slot" | "label">,
+  t?: TFunction,
+): string {
   const label = speaker.label?.trim();
   if (label && label.length > 0) return label;
+  if (t) return t("speakers.speaker", { n: speaker.slot + 1 });
   return `Speaker ${speaker.slot + 1}`;
 }
 

--- a/src/types/streaming.ts
+++ b/src/types/streaming.ts
@@ -19,14 +19,21 @@ export type AudioFormat = {
 /**
  * Where the backend should pull audio from.
  *
- * - `microphone`: default cpal input. Requires Microphone permission
- *   on macOS the first time it runs.
- * - `systemOutput`: the system audio mix (the "other side of the
- *   call"). macOS 13+ only — uses ScreenCaptureKit and requires
- *   Screen Recording permission. The backend ignores `deviceId` for
- *   this source.
+ * - `microphone`: default cpal input. Requires Microphone permission.
+ * - `systemOutput`: system audio loopback (macOS 13+, ScreenCaptureKit).
+ *   The backend ignores `deviceId` for this source.
+ * - `mixed`: microphone + system audio merged. Best with headphones:
+ *   mic captures the local speaker, system captures remote participants.
+ *   Use `setMixSources` to mute/unmute each channel during a session.
  */
-export type AudioSourceKind = "microphone" | "systemOutput";
+export type AudioSourceKind = "microphone" | "systemOutput" | "mixed";
+
+/** Information about the system's current default audio output device. */
+export type OutputDeviceInfo = {
+  name: string;
+  /** True when the device name suggests headphones / earbuds. */
+  isHeadphones: boolean;
+};
 
 export type StartStreamingOptions = {
   source?: AudioSourceKind;

--- a/src/types/summary.ts
+++ b/src/types/summary.ts
@@ -139,13 +139,14 @@ export const TEMPLATE_IDS = [
 
 export type TemplateId = (typeof TEMPLATE_IDS)[number];
 
-export const TEMPLATE_LABELS: Record<TemplateId, string> = {
-  general: "General",
-  oneOnOne: "1:1",
-  sprintReview: "Sprint Review",
-  interview: "Interview",
-  salesCall: "Sales Call",
-  lecture: "Lecture",
+/** i18n key for each built-in template label. */
+export const TEMPLATE_LABEL_KEYS: Record<TemplateId, string> = {
+  general: "templates.builtIn.general",
+  oneOnOne: "templates.builtIn.oneOnOne",
+  sprintReview: "templates.builtIn.sprintReview",
+  interview: "templates.builtIn.interview",
+  salesCall: "templates.builtIn.salesCall",
+  lecture: "templates.builtIn.lecture",
 };
 
 /**


### PR DESCRIPTION
## Summary

Audit and fix of hardcoded user-facing strings that were not using i18n translations.

### Changes

**High severity** (visible text rendered in wrong language for Spanish users):
- `TEMPLATE_LABELS` → replaced with `TEMPLATE_LABEL_KEYS` using `templates.builtIn.*` i18n keys
- `displayName()` in `speakers.ts` → added optional `TFunction` param for localized fallback
- `HealthProbe.tsx` → tooltip now uses existing `health.tooltip` key instead of manual template string

**Medium severity** (tooltips / aria-labels):
- `LivePane.tsx` → focus mode tooltip and aria-label now use `live.focusMode` / `live.toggleFocusMode`
- `LivePane.tsx` → language selector options show localized names (Español, English, Português…) instead of ISO codes
- `CopyButton.tsx` → default title falls back to `t("toast.copy")` instead of hardcoded "Copy"
- `MeetingDetail.tsx` → nav aria-label uses `meeting.sectionsNav`

**Low severity:**
- `useHardwareRecommendation.ts` → "Unknown error" uses `errors.unknownError`

### Files changed
- `src/i18n/locales/en.json` / `es.json` — new keys: `templates.builtIn.*`, `live.focusMode`, `live.toggleFocusMode`, `meeting.sectionsNav`, `errors.unknownError`, `languages.*`
- `src/types/summary.ts` — `TEMPLATE_LABELS` → `TEMPLATE_LABEL_KEYS`
- `src/lib/speakers.ts` — `displayName()` accepts optional `TFunction`
- `src/components/CopyButton.tsx` — uses `useTranslation` for default title
- `src/features/live/LivePane.tsx`, `HealthProbe.tsx`, `src/features/meetings/MeetingDetail.tsx`, `SpeakerEditor.tsx`, `SummaryPanel.tsx`, `src/hooks/useHardwareRecommendation.ts`